### PR TITLE
Enable live updates via Socket.IO

### DIFF
--- a/client/src/components/chat/MessageInput.js
+++ b/client/src/components/chat/MessageInput.js
@@ -18,11 +18,11 @@ const MessageInput = ({ chatId, onTyping }) => {
     if (!socket) return;
 
     if (isTyping) {
-      socket.emit('typing', { chatId });
+      socket.emit('typing', chatId);
     }
 
     if (debouncedTyping === false && isTyping) {
-      socket.emit('stop:typing', { chatId });
+      socket.emit('stop-typing', chatId);
       setIsTyping(false);
     }
   }, [isTyping, debouncedTyping, socket, chatId]);
@@ -94,7 +94,7 @@ const MessageInput = ({ chatId, onTyping }) => {
     try {
       // Stop typing indicator
       if (socket) {
-        socket.emit('stop:typing', { chatId });
+        socket.emit('stop-typing', chatId);
       }
       
       // Send message (attachments not yet supported)


### PR DESCRIPTION
## Summary
- join/leave chat rooms when selecting a chat
- align Socket.IO event names with backend
- emit `new-message` after sending a message
- update typing events to use `stop-typing`

## Testing
- `npm test` in `server` *(fails: no test specified)*
- `npm test --silent` in `client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ffc7d0cf483328cda8e35edbeecd5