### PR TITLE
Fix AuthContext socket dependency

### DIFF
--- a/client/src/components/modals/ProfileModal.js
+++ b/client/src/components/modals/ProfileModal.js
@@ -1,8 +1,10 @@
 import React, { useState, useRef } from 'react';
 import { useAuth } from '../../hooks/useAuth';
+import { useSocket } from '../../hooks/useSocket';
 
 const ProfileModal = ({ isOpen, onClose }) => {
   const { currentUser, updateProfile, updateAvatar } = useAuth();
+  const { socket } = useSocket();
   const [name, setName] = useState(currentUser?.name || '');
   const [email, setEmail] = useState(currentUser?.email || '');
   const [password, setPassword] = useState('');
@@ -65,7 +67,13 @@ const ProfileModal = ({ isOpen, onClose }) => {
 
       // Update avatar if changed
       if (avatar) {
-        await updateAvatar(avatar);
+        const data = await updateAvatar(avatar);
+        if (socket) {
+          socket.emit('avatar-updated', {
+            userId: currentUser._id,
+            avatar: data.avatar,
+          });
+        }
       }
 
       // Update profile details

--- a/client/src/contexts/AuthContext.js
+++ b/client/src/contexts/AuthContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect, useContext } from 'react';
+import React, { createContext, useState, useEffect } from 'react';
 import {
   loginUser,
   registerUser,
@@ -7,7 +7,6 @@ import {
   updateUserProfile,
   uploadAvatar as uploadAvatarApi,
 } from '../services/authService';
-import { SocketContext } from './SocketContext';
 
 export const AuthContext = createContext();
 
@@ -16,7 +15,6 @@ export const AuthProvider = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const { socket } = useContext(SocketContext);
 
   useEffect(() => {
     // Check if user is already logged in
@@ -95,9 +93,6 @@ export const AuthProvider = ({ children }) => {
   const updateAvatar = async (file) => {
     const data = await uploadAvatarApi(file);
     setCurrentUser(prev => ({ ...prev, avatar: data.avatar }));
-    if (socket) {
-      socket.emit('avatar-updated', { userId: currentUser._id, avatar: data.avatar });
-    }
     return data;
   };
 


### PR DESCRIPTION
## Summary
- remove SocketContext usage from AuthContext to avoid circular dependency
- emit `avatar-updated` event from ProfileModal instead

## Testing
- `npm test -- --watchAll=false` *(client - no tests)*
- `npm test -- --watchAll=false --passWithNoTests` *(client - pass)*
- `npm test` *(server - fails: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_6870053e9e3c8332854f69d5520b220c