### PR TITLE
Fix duplicate chat messages

### DIFF
--- a/server/services/socket.service.js
+++ b/server/services/socket.service.js
@@ -55,13 +55,10 @@ const socketService = (io) => {
       if (!chat.users) return console.log('Chat users not defined');
 
       // Send message to all users in the chat except the sender
+      // Emit only to each user's personal room to avoid duplicate events
       chat.users.forEach((user) => {
         if (user._id !== messageData.sender._id) {
-          // Emit to the specific user's room
           socket.to(user._id).emit('message-received', messageData);
-          
-          // Also emit to the chat room
-          socket.to(chat._id).emit('message-received', messageData);
         }
       });
     });


### PR DESCRIPTION
## Summary
- prevent sending chat messages twice over socket

## Testing
- `npm test` (fails: no test specified)
- `cd client && npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6872036cada08332adce19d0b41c1320