### PR TITLE
Add dark mode option

### DIFF
--- a/client/src/components/chat/ChatArea.js
+++ b/client/src/components/chat/ChatArea.js
@@ -146,18 +146,18 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
   };
 
   return (
-    <div className="flex-1 flex flex-col h-full bg-gray-50">
+    <div className="flex-1 flex flex-col h-full bg-gray-50 dark:bg-gray-900">
       {selectedChat ? (
         <>
           {/* Chat Header */}
-          <div className="bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
+          <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-3 flex items-center justify-between">
             <div className="flex items-center">
-              <button 
+              <button
                 onClick={toggleMobileMenu}
-                className="md:hidden p-2 mr-2 rounded-full hover:bg-gray-100"
+                className="md:hidden p-2 mr-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"
                 aria-label="Menu"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
                 </svg>
               </button>
@@ -168,24 +168,24 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
                   className="h-10 w-10 rounded-full object-cover"
                 />
                 <div className="ml-3">
-                  <h2 className="text-lg font-semibold text-gray-800">{getChatName()}</h2>
-                  <p className="text-sm text-gray-500">{getChatStatus()}</p>
+                  <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100">{getChatName()}</h2>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">{getChatStatus()}</p>
                 </div>
               </div>
             </div>
             <div>
               {selectedChat.isGroupChat ? (
-                <button 
+                <button
                   onClick={openGroupInfoModal}
-                  className="p-2 rounded-full hover:bg-gray-100"
+                  className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"
                   aria-label="Group Info"
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                 </button>
               ) : (
-                <button 
+                <button
                   onClick={() => {
                     const otherUser = selectedChat.users.find(
                       (p) => p._id !== currentUser._id
@@ -194,10 +194,10 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
                       openUserProfileModal(otherUser);
                     }
                   }}
-                  className="p-2 rounded-full hover:bg-gray-100"
+                  className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"
                   aria-label="User Info"
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                   </svg>
                 </button>
@@ -212,7 +212,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
                 <LoadingSpinner />
               </div>
             ) : messages.length === 0 ? (
-              <div className="flex flex-col items-center justify-center h-full text-gray-500">
+              <div className="flex flex-col items-center justify-center h-full text-gray-500 dark:text-gray-400">
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-16 w-16 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
                 </svg>
@@ -232,7 +232,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
           {/* Typing Indicator */}
           {getTypingText() && (
             <div className="px-4 py-2">
-              <div className="typing-indicator text-gray-500 text-sm">
+              <div className="typing-indicator text-gray-500 dark:text-gray-400 text-sm">
                 {getTypingText()}
                 <span></span>
                 <span></span>
@@ -242,7 +242,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
           )}
           
           {/* Message Input */}
-          <div className="border-t border-gray-200 p-4 bg-white">
+          <div className="border-t border-gray-200 dark:border-gray-700 p-4 bg-white dark:bg-gray-800">
             <MessageInput 
               chatId={selectedChat._id} 
               onTyping={handleTyping} 
@@ -250,12 +250,12 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
           </div>
         </>
       ) : (
-        <div className="flex flex-col items-center justify-center h-full bg-gray-50 p-4">
+        <div className="flex flex-col items-center justify-center h-full bg-gray-50 dark:bg-gray-900 p-4">
           <svg xmlns="http://www.w3.org/2000/svg" className="h-24 w-24 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
           </svg>
-          <h2 className="mt-4 text-xl font-semibold text-gray-700">Welcome to LiveChat</h2>
-          <p className="mt-2 text-gray-500 text-center max-w-md">
+          <h2 className="mt-4 text-xl font-semibold text-gray-700 dark:text-gray-100">Welcome to LiveChat</h2>
+          <p className="mt-2 text-gray-500 dark:text-gray-400 text-center max-w-md">
             Select a chat from the sidebar or search for users to start a new conversation.
           </p>
           <button 

--- a/client/src/components/chat/ChatList.js
+++ b/client/src/components/chat/ChatList.js
@@ -69,7 +69,7 @@ const ChatList = ({ chats, openUserProfileModal }) => {
   };
 
   return (
-    <div className="divide-y divide-gray-200">
+    <div className="divide-y divide-gray-200 dark:divide-gray-700">
       {chats.map((chat) => {
         const isSelected = selectedChat && selectedChat._id === chat._id;
         const unreadCount = unreadCounts[chat._id] || 0;
@@ -77,9 +77,9 @@ const ChatList = ({ chats, openUserProfileModal }) => {
         const isOnline = isChatUserOnline(chat);
         
         return (
-          <div 
+          <div
             key={chat._id}
-            className={`p-4 cursor-pointer hover:bg-gray-50 ${isSelected ? 'bg-gray-100' : ''}`}
+            className={`p-4 cursor-pointer bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 ${isSelected ? 'bg-gray-100 dark:bg-gray-700' : ''}`}
             onClick={() => setSelectedChat(chat)}
           >
             <div className="flex items-center">
@@ -95,13 +95,13 @@ const ChatList = ({ chats, openUserProfileModal }) => {
               </div>
               <div className="ml-3 flex-1 overflow-hidden">
                 <div className="flex items-center justify-between">
-                  <h3 className="text-sm font-medium text-gray-900 truncate">{chatName}</h3>
-                  <p className="text-xs text-gray-500">
+                  <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{chatName}</h3>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
                     {formatTime(chat.latestMessage?.createdAt)}
                   </p>
                 </div>
                 <div className="flex items-center justify-between mt-1">
-                  <p className="text-sm text-gray-500 truncate">
+                  <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
                     {getLatestMessagePreview(chat)}
                   </p>
                   {unreadCount > 0 && (

--- a/client/src/components/chat/MessageInput.js
+++ b/client/src/components/chat/MessageInput.js
@@ -175,12 +175,12 @@ const MessageInput = ({ chatId, onTyping }) => {
   };
 
   return (
-    <div className="p-4 border-t">
+    <div className="p-4 border-t border-gray-200 dark:border-gray-700">
       {/* Attachment previews */}
       {attachments.length > 0 && (
         <div className="flex flex-wrap gap-2 mb-3">
           {previewAttachments.map((attachment, index) => (
-            <div key={index} className="relative bg-gray-100 rounded-md p-2 flex items-center">
+            <div key={index} className="relative bg-gray-100 dark:bg-gray-700 rounded-md p-2 flex items-center">
               <div className="mr-2 text-gray-600">
                 {getFileIcon(attachment.type)}
               </div>
@@ -207,7 +207,7 @@ const MessageInput = ({ chatId, onTyping }) => {
         <button 
           type="button"
           onClick={() => fileInputRef.current.click()}
-          className="p-2 text-gray-500 hover:text-primary-600 focus:outline-none"
+          className="p-2 text-gray-500 dark:text-gray-400 hover:text-primary-600 focus:outline-none"
           aria-label="Attach file"
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -227,7 +227,7 @@ const MessageInput = ({ chatId, onTyping }) => {
           value={message} 
           onChange={handleInputChange} 
           placeholder="Type a message..." 
-          className="flex-1 p-3 rounded-full bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 mx-2" 
+          className="flex-1 p-3 rounded-full bg-gray-100 dark:bg-gray-700 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 mx-2"
         />
         
         <button 

--- a/client/src/components/chat/Sidebar.js
+++ b/client/src/components/chat/Sidebar.js
@@ -3,6 +3,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { useChat } from '../../hooks/useChat';
 import { useDebounce } from '../../hooks/useDebounce';
 import { userService } from '../../services';
+import { useTheme } from '../../hooks/useTheme';
 
 // Components
 import ChatList from './ChatList';
@@ -18,6 +19,7 @@ const Sidebar = ({
 }) => {
   const { currentUser, logout } = useAuth();
   const { chats, chatLoading, fetchChats, createOrAccessChat, getTotalUnreadCount } = useChat();
+  const { theme, toggleTheme } = useTheme();
   
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState([]);
@@ -78,11 +80,11 @@ const Sidebar = ({
   };
 
   return (
-    <div 
-      className={`w-full md:w-80 bg-white border-r border-gray-200 flex flex-col h-full ${isMobileMenuOpen ? 'block' : 'hidden md:flex'}`}
+    <div
+      className={`w-full md:w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col h-full ${isMobileMenuOpen ? 'block' : 'hidden md:flex'}`}
     >
       {/* Header */}
-      <div className="p-4 border-b border-gray-200 flex items-center justify-between">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
         <div className="flex items-center">
           <img
             src={currentUser?.avatar || `https://ui-avatars.com/api/?name=${encodeURIComponent(currentUser?.name || 'User')}&background=random`}
@@ -90,33 +92,48 @@ const Sidebar = ({
             className="h-10 w-10 rounded-full object-cover"
           />
           <div className="ml-3">
-            <h2 className="text-lg font-semibold text-gray-800">{currentUser?.name || 'User'}</h2>
-            <p className="text-sm text-gray-500">{currentUser?.status || 'Online'}</p>
+            <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100">{currentUser?.name || 'User'}</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">{currentUser?.status || 'Online'}</p>
           </div>
         </div>
         <div className="flex">
-          <button 
+          <button
             onClick={openProfileModal}
-            className="p-2 rounded-full hover:bg-gray-100"
+            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"
             aria-label="Profile"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
             </svg>
           </button>
-          <button 
+          <button
             onClick={handleLogout}
-            className="p-2 rounded-full hover:bg-gray-100 ml-1"
+            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 ml-1"
             aria-label="Logout"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
             </svg>
           </button>
-          <button 
+          <button
+            onClick={toggleTheme}
+            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 ml-1"
+            aria-label="Toggle theme"
+          >
+            {theme === 'dark' ? (
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4.22 2.22a1 1 0 011.42 0l.7.7a1 1 0 11-1.42 1.42l-.7-.7a1 1 0 010-1.42zM17 9a1 1 0 100 2h1a1 1 0 100-2h-1zM4.22 4.22a1 1 0 00-1.42 1.42l.7.7a1 1 0 001.42-1.42l-.7-.7zM3 9a1 1 0 100 2H2a1 1 0 100-2h1zm1.22 6.78a1 1 0 011.42 0l.7.7a1 1 0 01-1.42 1.42l-.7-.7a1 1 0 010-1.42zM10 17a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zm6.78-1.22a1 1 0 00-1.42-1.42l-.7.7a1 1 0 001.42 1.42l.7-.7zM10 5a5 5 0 100 10 5 5 0 000-10z" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M17.293 13.293a8 8 0 01-11.586-11.586 8 8 0 1011.586 11.586z" />
+              </svg>
+            )}
+          </button>
+          <button
             onClick={toggleMobileMenu}
-            className="p-2 rounded-full hover:bg-gray-100 ml-1 md:hidden"
+            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 ml-1 md:hidden"
             aria-label="Close menu"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -127,12 +144,12 @@ const Sidebar = ({
       </div>
       
       {/* Search */}
-      <div className="p-4 border-b border-gray-200">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700">
         <div className="relative">
           <input
             type="text"
             placeholder="Search users..."
-            className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+            className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-800 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:text-gray-100"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />
@@ -143,8 +160,8 @@ const Sidebar = ({
           </div>
         </div>
         <div className="flex justify-between mt-4">
-          <button 
-            className={`flex-1 py-2 text-sm font-medium ${activeTab === 'chats' ? 'text-primary-600 border-b-2 border-primary-600' : 'text-gray-500 hover:text-gray-700'}`}
+          <button
+            className={`flex-1 py-2 text-sm font-medium ${activeTab === 'chats' ? 'text-primary-600 border-b-2 border-primary-600' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700'}`}
             onClick={() => setActiveTab('chats')}
           >
             Chats
@@ -154,8 +171,8 @@ const Sidebar = ({
               </span>
             )}
           </button>
-          <button 
-            className={`flex-1 py-2 text-sm font-medium ${activeTab === 'search' ? 'text-primary-600 border-b-2 border-primary-600' : 'text-gray-500 hover:text-gray-700'}`}
+          <button
+            className={`flex-1 py-2 text-sm font-medium ${activeTab === 'search' ? 'text-primary-600 border-b-2 border-primary-600' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700'}`}
             onClick={() => {
               if (searchQuery) {
                 setActiveTab('search');
@@ -191,7 +208,7 @@ const Sidebar = ({
               <LoadingSpinner />
             </div>
           ) : chats.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
+            <div className="text-center py-8 text-gray-500 dark:text-gray-400">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-12 w-12 mx-auto text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
               </svg>
@@ -212,7 +229,7 @@ const Sidebar = ({
               <p>{searchError}</p>
             </div>
           ) : searchResults.length === 0 ? (
-            <div className="text-center py-8 text-gray-500">
+            <div className="text-center py-8 text-gray-500 dark:text-gray-400">
               <p>No users found</p>
             </div>
           ) : (

--- a/client/src/contexts/ThemeContext.js
+++ b/client/src/contexts/ThemeContext.js
@@ -1,0 +1,37 @@
+import React, { createContext, useState, useEffect } from 'react';
+
+export const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState('light');
+
+  // Apply stored or preferred theme on mount
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initial = stored || (prefersDark ? 'dark' : 'light');
+    setTheme(initial);
+    updateHtmlClass(initial);
+  }, []);
+
+  const updateHtmlClass = (value) => {
+    if (value === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  };
+
+  const toggleTheme = () => {
+    const next = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    localStorage.setItem('theme', next);
+    updateHtmlClass(next);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/client/src/hooks/useTheme.js
+++ b/client/src/hooks/useTheme.js
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { ThemeContext } from '../contexts/ThemeContext';
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -7,7 +7,7 @@
     @apply h-full;
   }
   body {
-    @apply h-full bg-gray-50 text-gray-900 antialiased;
+    @apply h-full bg-gray-50 text-gray-900 antialiased dark:bg-gray-900 dark:text-gray-100;
   }
   #root {
     @apply h-full;
@@ -22,16 +22,16 @@
     @apply bg-primary-600 text-white hover:bg-primary-700;
   }
   .btn-secondary {
-    @apply bg-secondary-200 text-secondary-900 hover:bg-secondary-300;
+    @apply bg-secondary-200 text-secondary-900 hover:bg-secondary-300 dark:bg-secondary-700 dark:text-secondary-100 dark:hover:bg-secondary-600;
   }
   .btn-danger {
     @apply bg-red-600 text-white hover:bg-red-700;
   }
   .input {
-    @apply block w-full rounded-md border border-gray-300 px-3 py-2 text-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500;
+    @apply block w-full rounded-md border border-gray-300 px-3 py-2 text-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-300;
   }
   .card {
-    @apply rounded-lg bg-white shadow;
+    @apply rounded-lg bg-white shadow dark:bg-gray-800;
   }
 }
 
@@ -59,7 +59,7 @@
 }
 
 .message-bubble.received {
-  @apply bg-gray-200 text-gray-800 mr-auto rounded-bl-none;
+  @apply bg-gray-200 text-gray-800 mr-auto rounded-bl-none dark:bg-gray-700 dark:text-gray-100;
 }
 
 /* Typing indicator animation */

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -6,18 +6,21 @@ import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
 import { ChatProvider } from './contexts/ChatContext';
 import { SocketProvider } from './contexts/SocketContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <AuthProvider>
-        <SocketProvider>
-          <ChatProvider>
-            <App />
-          </ChatProvider>
-        </SocketProvider>
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <SocketProvider>
+            <ChatProvider>
+              <App />
+            </ChatProvider>
+          </SocketProvider>
+        </AuthProvider>
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
     "./public/index.html"


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode
- add ThemeContext with persistence
- add theme toggle button in chat sidebar
- style components for dark mode

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `npm test --prefix client --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68720a527b508332954a1224168ba7c7