### PR TITLE
Fix group chat creation

### DIFF
--- a/client/src/contexts/ChatContext.js
+++ b/client/src/contexts/ChatContext.js
@@ -253,12 +253,12 @@ export const ChatProvider = ({ children }) => {
     setError(null);
     try {
       const data = await accessChat(userId);
-      
+
       // Check if chat already exists in the list
       const chatExists = chats.find(c => c._id === data._id);
-      
+
       if (!chatExists) {
-        setChats([data, ...chats]);
+        setChats(prev => [data, ...prev]);
       }
       
       setSelectedChat(data);
@@ -277,7 +277,7 @@ export const ChatProvider = ({ children }) => {
     setError(null);
     try {
       const data = await createGroupChat(users, name);
-      setChats([data, ...chats]);
+      setChats(prev => [data, ...prev]);
       return data;
     } catch (err) {
       setError(err.message || 'Failed to create group chat');
@@ -294,9 +294,11 @@ export const ChatProvider = ({ children }) => {
       const data = await renameGroup(chatId, name);
       
       // Update chats list
-      setChats(chats.map(chat => 
-        chat._id === chatId ? data : chat
-      ));
+      setChats(prev =>
+        prev.map(chat =>
+          chat._id === chatId ? data : chat
+        )
+      );
       
       // Update selected chat if it's the one being renamed
       if (selectedChat && selectedChat._id === chatId) {
@@ -319,9 +321,11 @@ export const ChatProvider = ({ children }) => {
       const data = await addToGroup(chatId, userId);
       
       // Update chats list
-      setChats(chats.map(chat => 
-        chat._id === chatId ? data : chat
-      ));
+      setChats(prev =>
+        prev.map(chat =>
+          chat._id === chatId ? data : chat
+        )
+      );
       
       // Update selected chat if it's the one being modified
       if (selectedChat && selectedChat._id === chatId) {
@@ -344,9 +348,11 @@ export const ChatProvider = ({ children }) => {
       const data = await removeFromGroup(chatId, userId);
       
       // Update chats list
-      setChats(chats.map(chat => 
-        chat._id === chatId ? data : chat
-      ));
+      setChats(prev =>
+        prev.map(chat =>
+          chat._id === chatId ? data : chat
+        )
+      );
       
       // Update selected chat if it's the one being modified
       if (selectedChat && selectedChat._id === chatId) {
@@ -369,7 +375,7 @@ export const ChatProvider = ({ children }) => {
       await leaveGroup(chatId);
       
       // Remove chat from list
-      setChats(chats.filter(chat => chat._id !== chatId));
+      setChats(prev => prev.filter(chat => chat._id !== chatId));
       
       // Clear selected chat if it's the one being left
       if (selectedChat && selectedChat._id === chatId) {

--- a/client/src/services/chatService.js
+++ b/client/src/services/chatService.js
@@ -55,7 +55,7 @@ export const createGroupChat = async (users, name) => {
  */
 export const renameGroup = async (chatId, name) => {
   try {
-    const response = await axios.put(`${API_URL}/chats/group/rename`, { chatId, name });
+    const response = await axios.put(`${API_URL}/chats/group/${chatId}`, { name });
     return response.data;
   } catch (error) {
     throw error.response?.data || { message: 'Failed to rename group' };
@@ -70,7 +70,7 @@ export const renameGroup = async (chatId, name) => {
  */
 export const addToGroup = async (chatId, userId) => {
   try {
-    const response = await axios.put(`${API_URL}/chats/group/add`, { chatId, userId });
+    const response = await axios.put(`${API_URL}/chats/group/${chatId}/add`, { userId });
     return response.data;
   } catch (error) {
     throw error.response?.data || { message: 'Failed to add user to group' };
@@ -85,7 +85,7 @@ export const addToGroup = async (chatId, userId) => {
  */
 export const removeFromGroup = async (chatId, userId) => {
   try {
-    const response = await axios.put(`${API_URL}/chats/group/remove`, { chatId, userId });
+    const response = await axios.put(`${API_URL}/chats/group/${chatId}/remove`, { userId });
     return response.data;
   } catch (error) {
     throw error.response?.data || { message: 'Failed to remove user from group' };
@@ -99,7 +99,7 @@ export const removeFromGroup = async (chatId, userId) => {
  */
 export const leaveGroup = async (chatId) => {
   try {
-    const response = await axios.put(`${API_URL}/chats/group/leave`, { chatId });
+    const response = await axios.put(`${API_URL}/chats/group/${chatId}/leave`);
     return response.data;
   } catch (error) {
     throw error.response?.data || { message: 'Failed to leave group' };


### PR DESCRIPTION
## Summary
- fix stale state when updating chat list
- ensure newly created or modified group chats appear immediately

## Testing
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm test -- --watchAll=false --passWithNoTests` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68720d4c54ec8332bc9360fc4f8e93f5