### PR TITLE
Improve dark mode colors

### DIFF
--- a/client/src/components/chat/ChatArea.js
+++ b/client/src/components/chat/ChatArea.js
@@ -146,11 +146,11 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
   };
 
   return (
-    <div className="flex-1 flex flex-col h-full bg-gray-50 dark:bg-gray-900">
+    <div className="flex-1 flex flex-col h-full bg-gray-50 dark:bg-gray-700">
       {selectedChat ? (
         <>
           {/* Chat Header */}
-          <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-3 flex items-center justify-between">
+          <div className="bg-white dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600 px-4 py-3 flex items-center justify-between">
             <div className="flex items-center">
               <button
                 onClick={toggleMobileMenu}
@@ -242,7 +242,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
           )}
           
           {/* Message Input */}
-          <div className="border-t border-gray-200 dark:border-gray-700 p-4 bg-white dark:bg-gray-800">
+          <div className="border-t border-gray-200 dark:border-gray-600 p-4 bg-white dark:bg-gray-700">
             <MessageInput 
               chatId={selectedChat._id} 
               onTyping={handleTyping} 
@@ -250,7 +250,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
           </div>
         </>
       ) : (
-        <div className="flex flex-col items-center justify-center h-full bg-gray-50 dark:bg-gray-900 p-4">
+        <div className="flex flex-col items-center justify-center h-full bg-gray-50 dark:bg-gray-700 p-4">
           <svg xmlns="http://www.w3.org/2000/svg" className="h-24 w-24 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
           </svg>

--- a/client/src/components/chat/ChatList.js
+++ b/client/src/components/chat/ChatList.js
@@ -69,7 +69,7 @@ const ChatList = ({ chats, openUserProfileModal }) => {
   };
 
   return (
-    <div className="divide-y divide-gray-200 dark:divide-gray-700">
+    <div className="divide-y divide-gray-200 dark:divide-gray-600">
       {chats.map((chat) => {
         const isSelected = selectedChat && selectedChat._id === chat._id;
         const unreadCount = unreadCounts[chat._id] || 0;
@@ -79,7 +79,7 @@ const ChatList = ({ chats, openUserProfileModal }) => {
         return (
           <div
             key={chat._id}
-            className={`p-4 cursor-pointer bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 ${isSelected ? 'bg-gray-100 dark:bg-gray-700' : ''}`}
+            className={`p-4 cursor-pointer bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 ${isSelected ? 'bg-gray-100 dark:bg-gray-600' : ''}`}
             onClick={() => setSelectedChat(chat)}
           >
             <div className="flex items-center">

--- a/client/src/components/chat/MessageInput.js
+++ b/client/src/components/chat/MessageInput.js
@@ -175,12 +175,12 @@ const MessageInput = ({ chatId, onTyping }) => {
   };
 
   return (
-    <div className="p-4 border-t border-gray-200 dark:border-gray-700">
+    <div className="p-4 border-t border-gray-200 dark:border-gray-600">
       {/* Attachment previews */}
       {attachments.length > 0 && (
         <div className="flex flex-wrap gap-2 mb-3">
           {previewAttachments.map((attachment, index) => (
-            <div key={index} className="relative bg-gray-100 dark:bg-gray-700 rounded-md p-2 flex items-center">
+            <div key={index} className="relative bg-gray-100 dark:bg-gray-600 rounded-md p-2 flex items-center">
               <div className="mr-2 text-gray-600">
                 {getFileIcon(attachment.type)}
               </div>
@@ -227,7 +227,7 @@ const MessageInput = ({ chatId, onTyping }) => {
           value={message} 
           onChange={handleInputChange} 
           placeholder="Type a message..." 
-          className="flex-1 p-3 rounded-full bg-gray-100 dark:bg-gray-700 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 mx-2"
+          className="flex-1 p-3 rounded-full bg-gray-100 dark:bg-gray-600 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500 mx-2"
         />
         
         <button 

--- a/client/src/components/chat/Sidebar.js
+++ b/client/src/components/chat/Sidebar.js
@@ -81,10 +81,10 @@ const Sidebar = ({
 
   return (
     <div
-      className={`w-full md:w-80 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col h-full ${isMobileMenuOpen ? 'block' : 'hidden md:flex'}`}
+      className={`w-full md:w-80 bg-white dark:bg-gray-700 border-r border-gray-200 dark:border-gray-600 flex flex-col h-full ${isMobileMenuOpen ? 'block' : 'hidden md:flex'}`}
     >
       {/* Header */}
-      <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-600 flex items-center justify-between">
         <div className="flex items-center">
           <img
             src={currentUser?.avatar || `https://ui-avatars.com/api/?name=${encodeURIComponent(currentUser?.name || 'User')}&background=random`}
@@ -99,7 +99,7 @@ const Sidebar = ({
         <div className="flex">
           <button
             onClick={openProfileModal}
-            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"
+            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-600"
             aria-label="Profile"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -109,7 +109,7 @@ const Sidebar = ({
           </button>
           <button
             onClick={handleLogout}
-            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 ml-1"
+            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-600 ml-1"
             aria-label="Logout"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -118,7 +118,7 @@ const Sidebar = ({
           </button>
           <button
             onClick={toggleTheme}
-            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 ml-1"
+            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-600 ml-1"
             aria-label="Toggle theme"
           >
             {theme === 'dark' ? (
@@ -143,7 +143,7 @@ const Sidebar = ({
           </button>
           <button
             onClick={toggleMobileMenu}
-            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 ml-1 md:hidden"
+            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-600 ml-1 md:hidden"
             aria-label="Close menu"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -154,12 +154,12 @@ const Sidebar = ({
       </div>
       
       {/* Search */}
-      <div className="p-4 border-b border-gray-200 dark:border-gray-700">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-600">
         <div className="relative">
           <input
             type="text"
             placeholder="Search users..."
-            className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-800 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:text-gray-100"
+            className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-500 dark:bg-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:text-gray-100"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -7,7 +7,7 @@
     @apply h-full;
   }
   body {
-    @apply h-full bg-gray-50 text-gray-900 antialiased dark:bg-gray-900 dark:text-gray-100;
+    @apply h-full bg-gray-50 text-gray-900 antialiased dark:bg-gray-800 dark:text-gray-100;
   }
   #root {
     @apply h-full;
@@ -28,10 +28,10 @@
     @apply bg-red-600 text-white hover:bg-red-700;
   }
   .input {
-    @apply block w-full rounded-md border border-gray-300 px-3 py-2 text-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-300;
+    @apply block w-full rounded-md border border-gray-300 px-3 py-2 text-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-600 dark:border-gray-500 dark:text-gray-100 dark:placeholder-gray-300;
   }
   .card {
-    @apply rounded-lg bg-white shadow dark:bg-gray-800;
+    @apply rounded-lg bg-white shadow dark:bg-gray-700;
   }
 }
 
@@ -59,7 +59,7 @@
 }
 
 .message-bubble.received {
-  @apply bg-gray-200 text-gray-800 mr-auto rounded-bl-none dark:bg-gray-700 dark:text-gray-100;
+  @apply bg-gray-200 text-gray-800 mr-auto rounded-bl-none dark:bg-gray-600 dark:text-gray-100;
 }
 
 /* Typing indicator animation */

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -27,7 +27,7 @@ const Login = () => {
   };
 
   return (
-    <div className="min-h-full flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-full flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-gray-800">
       <div className="max-w-md w-full space-y-8">
         <div>
           <div className="flex justify-center">
@@ -45,7 +45,7 @@ const Login = () => {
         </div>
         
         {error && (
-          <div className="bg-red-50 border-l-4 border-red-400 p-4 dark:bg-gray-800 dark:border-red-500">
+          <div className="bg-red-50 border-l-4 border-red-400 p-4 dark:bg-gray-700 dark:border-red-500">
             <div className="flex">
               <div className="flex-shrink-0">
                 <svg className="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
@@ -69,7 +69,7 @@ const Login = () => {
                 type="email"
                 autoComplete="email"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-400"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
                 placeholder="Email address"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -83,7 +83,7 @@ const Login = () => {
                 type="password"
                 autoComplete="current-password"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-400"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
                 placeholder="Password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}

--- a/client/src/pages/NotFound.js
+++ b/client/src/pages/NotFound.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 const NotFound = () => {
   return (
-    <div className="min-h-full flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-full flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-gray-800">
       <div className="max-w-md w-full text-center">
         <div className="flex justify-center">
           <svg className="h-24 w-24 text-primary-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -55,7 +55,7 @@ const Register = () => {
   };
 
   return (
-    <div className="min-h-full flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-full flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-gray-800">
       <div className="max-w-md w-full space-y-8">
         <div>
           <div className="flex justify-center">
@@ -73,7 +73,7 @@ const Register = () => {
         </div>
         
         {error && (
-          <div className="bg-red-50 border-l-4 border-red-400 p-4 dark:bg-gray-800 dark:border-red-500">
+          <div className="bg-red-50 border-l-4 border-red-400 p-4 dark:bg-gray-700 dark:border-red-500">
             <div className="flex">
               <div className="flex-shrink-0">
                 <svg className="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
@@ -97,7 +97,7 @@ const Register = () => {
                 type="text"
                 autoComplete="name"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-400"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
                 placeholder="Full name"
                 value={formData.name}
                 onChange={handleChange}
@@ -111,7 +111,7 @@ const Register = () => {
                 type="email"
                 autoComplete="email"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-400"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
                 placeholder="Email address"
                 value={formData.email}
                 onChange={handleChange}
@@ -125,7 +125,7 @@ const Register = () => {
                 type="password"
                 autoComplete="new-password"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-400"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
                 placeholder="Password"
                 value={formData.password}
                 onChange={handleChange}
@@ -139,7 +139,7 @@ const Register = () => {
                 type="password"
                 autoComplete="new-password"
                 required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100 dark:placeholder-gray-400"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
                 placeholder="Confirm password"
                 value={formData.confirmPassword}
                 onChange={handleChange}


### PR DESCRIPTION
## Summary
- adjust general dark background colors
- soften borders and hover states in dark mode
- update form and message styles for better contrast

## Testing
- `npm test --prefix client -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6878f338ea0c83329a2abae9ab768743