### PR TITLE
Enhance Telegram-style chat bubbles

### DIFF
--- a/client/src/components/chat/MessageList.js
+++ b/client/src/components/chat/MessageList.js
@@ -56,7 +56,7 @@ const handleDeleteMessage = async (messageId, scope) => {
   // Render attachment
   const renderAttachment = (attachment) => {
     const type = attachment.type.split('/')[0];
-    
+
     switch (type) {
       case 'image':
         return (
@@ -64,7 +64,7 @@ const handleDeleteMessage = async (messageId, scope) => {
             <img
               src={attachment.url}
               alt={attachment.name || 'Image'}
-              className="max-w-full h-auto max-h-60 object-cover rounded-md shadow cursor-pointer"
+              className="max-w-full h-auto max-h-60 object-cover rounded-md shadow cursor-pointer transition-transform hover:scale-105"
               onClick={() => setSelectedImage(attachment.url)}
             />
             {attachment.name && (
@@ -77,8 +77,8 @@ const handleDeleteMessage = async (messageId, scope) => {
       case 'video':
         return (
           <div className="mt-2">
-            <video 
-              controls 
+            <video
+              controls
               className="max-w-full rounded-lg max-h-60"
             >
               <source src={attachment.url} type={attachment.type} />
@@ -107,7 +107,7 @@ const handleDeleteMessage = async (messageId, scope) => {
         );
       default:
         return (
-          <div className="mt-2 p-3 bg-gray-100 rounded-lg flex items-center">
+          <div className="mt-2 p-3 bg-gray-100 rounded-lg flex items-center hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors">
             <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
             </svg>
@@ -151,7 +151,7 @@ const handleDeleteMessage = async (messageId, scope) => {
               </div>
             </div>
 
-            <div className="space-y-4">
+            <div className="space-y-2">
               {groupedMessages[date].map((message) => {
               const isSentByMe = message.sender._id === currentUser._id;
               
@@ -178,11 +178,11 @@ const handleDeleteMessage = async (messageId, scope) => {
                         </div>
                       )}
                       
-                      <div 
+                      <div
                         className={`message-bubble ${isSentByMe ? 'sent' : 'received'}`}
                       >
                         {message.content && <div>{message.content}</div>}
-                        
+
                         {message.attachments && message.attachments.length > 0 && (
                           <div className="space-y-2">
                             {message.attachments.map((attachment, index) => (
@@ -192,12 +192,11 @@ const handleDeleteMessage = async (messageId, scope) => {
                             ))}
                           </div>
                         )}
+
+                        <div className="timestamp">{formatTime(message.createdAt)}</div>
                       </div>
-                      
+
                       <div className="flex items-center mt-1">
-                        <span className="text-xs text-gray-500 dark:text-gray-400">
-                          {formatTime(message.createdAt)}
-                        </span>
                         
                         {isSentByMe && (
                           <>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -59,15 +59,26 @@
 
 /* Message bubble styles */
 .message-bubble {
-  @apply max-w-[75%] rounded-lg px-4 py-2 mb-2 break-words;
+  /* extra padding on the bottom-right so the timestamp fits without overlapping */
+  @apply relative max-w-[75%] pl-3 pr-9 pt-2 pb-5 mb-1 rounded-lg break-words whitespace-pre-line shadow;
 }
 
 .message-bubble.sent {
-  @apply bg-primary-500 text-white ml-auto rounded-br-none;
+  background-color: #4fa3f7;
+  @apply text-white ml-auto rounded-br-none;
 }
 
 .message-bubble.received {
-  @apply bg-gray-200 text-gray-800 mr-auto rounded-bl-none dark:bg-gray-600 dark:text-gray-100;
+  @apply mr-auto rounded-bl-none text-gray-900 bg-gray-100 dark:text-gray-100;
+  background-color: #f1f1f1;
+}
+
+.dark .message-bubble.received {
+  background-color: #2A2F32;
+}
+
+.message-bubble .timestamp {
+  @apply absolute bottom-1 right-2 text-[10px] text-gray-400;
 }
 
 /* Typing indicator animation */


### PR DESCRIPTION
## Summary
- refine message bubble styling and add shadows
- show timestamps inside each bubble
- reduce spacing between messages
- add hover effects for attachments
- add padding so timestamps don't overlap content

## Testing
- `CI=true npm test --prefix client --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6879f345f1e48332a4b9586c54a70437