### PR TITLE
Fix chat message text rendering

### DIFF
--- a/client/src/components/chat/MessageList.js
+++ b/client/src/components/chat/MessageList.js
@@ -181,7 +181,11 @@ const handleDeleteMessage = async (messageId, scope) => {
                       <div
                         className={`message-bubble ${isSentByMe ? 'sent' : 'received'}`}
                       >
-                        {message.content && <div>{message.content}</div>}
+                        {message.content && (
+                          <div className="whitespace-pre-line break-words">
+                            {message.content}
+                          </div>
+                        )}
 
                         {message.attachments && message.attachments.length > 0 && (
                           <div className="space-y-2">


### PR DESCRIPTION
## Summary
- preserve line breaks when displaying message content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879fb47ea6c8332ad0524ee764d0273