### PR TITLE
Add password reset support and normalize email input

### DIFF
--- a/server/models/user.model.js
+++ b/server/models/user.model.js
@@ -47,7 +47,9 @@ const userSchema = new mongoose.Schema(
     socketId: {
       type: String,
       default: null
-    }
+    },
+    resetPasswordToken: String,
+    resetPasswordExpire: Date
   },
   {
     timestamps: true

--- a/server/routes/auth.routes.js
+++ b/server/routes/auth.routes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { register, login, getProfile, updateProfile, logout, uploadAvatar } = require('../controllers/auth.controller');
+const { register, login, getProfile, updateProfile, logout, uploadAvatar, forgotPassword, resetPassword } = require('../controllers/auth.controller');
 const multer = require('multer');
 const upload = multer({ storage: multer.memoryStorage() });
 const { protect } = require('../middleware/auth.middleware');
@@ -8,6 +8,8 @@ const { protect } = require('../middleware/auth.middleware');
 // Public routes
 router.post('/register', register);
 router.post('/login', login);
+router.post('/forgot-password', forgotPassword);
+router.post('/reset-password', resetPassword);
 
 // Protected routes
 router.get('/profile', protect, getProfile);


### PR DESCRIPTION
## Summary
- trim and lowercase emails during registration, login, and profile updates
- add password reset token generation and password reset endpoints

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895ecf61fbc8332a97f89736bd6cda4