### PR TITLE
feat: add animated register page

### DIFF
--- a/client/src/components/bear/RegisterForm.js
+++ b/client/src/components/bear/RegisterForm.js
@@ -1,0 +1,194 @@
+import React, { useState, useRef } from 'react';
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
+import { useAuth } from '../../hooks/useAuth';
+import { useNavigate } from 'react-router-dom';
+
+export function RegisterForm({
+  nameValue,
+  emailValue,
+  passwordValue,
+  confirmPasswordValue,
+  isPasswordVisible,
+  isConfirmPasswordVisible,
+  setNameValue,
+  setEmailValue,
+  setPasswordValue,
+  setConfirmPasswordValue,
+  setIsPasswordVisible,
+  setIsConfirmPasswordVisible,
+  setIsEmailFocused,
+  setIsPasswordFocused,
+  setIsConfirmPasswordFocused,
+}) {
+  const emailInputRef = useRef(null);
+  const [errorMessage, setErrorMessage] = useState('');
+  const { register } = useAuth();
+  const navigate = useNavigate();
+
+  const handleEmailFocus = () => {
+    setIsEmailFocused(true);
+    setTimeout(() => {
+      if (emailInputRef.current) {
+        emailInputRef.current.selectionStart = emailInputRef.current.value.length;
+      }
+    }, 0);
+  };
+
+  const togglePasswordVisibility = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsPasswordVisible(!isPasswordVisible);
+  };
+
+  const toggleConfirmPasswordVisibility = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsConfirmPasswordVisible(!isConfirmPasswordVisible);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!nameValue || !emailValue || !passwordValue || !confirmPasswordValue) {
+      setErrorMessage('Please fill in all fields');
+      return;
+    }
+    const emailRegex = /^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/;
+    if (!emailRegex.test(emailValue)) {
+      setErrorMessage('Please enter a valid email address');
+      return;
+    }
+    if (passwordValue !== confirmPasswordValue) {
+      setErrorMessage('Passwords do not match');
+      return;
+    }
+    if (passwordValue.length < 6) {
+      setErrorMessage('Password must be at least 6 characters');
+      return;
+    }
+    try {
+      await register({
+        name: nameValue,
+        email: emailValue,
+        password: passwordValue,
+      });
+      setErrorMessage('');
+      navigate('/');
+    } catch (err) {
+      setErrorMessage(err.response?.data?.message || 'Registration failed');
+    }
+  };
+
+  const handleLogin = () => {
+    navigate('/login');
+  };
+
+  return (
+    <form className="w-full space-y-6" onSubmit={handleSubmit}>
+      {errorMessage && (
+        <div className="p-3 text-sm text-white bg-red-500 rounded-lg">{errorMessage}</div>
+      )}
+      <div className="space-y-2">
+        <label htmlFor="name" className="block text-sm font-medium text-white">
+          Name
+        </label>
+        <input
+          id="name"
+          type="text"
+          value={nameValue}
+          onChange={(e) => setNameValue(e.target.value)}
+          className="w-full px-4 py-3 text-gray-800 transition-all duration-200 bg-white border-0 rounded-lg shadow-md focus:ring-2 focus:ring-blue-400 focus:outline-none"
+          placeholder="Your name"
+        />
+      </div>
+      <div className="space-y-2">
+        <label htmlFor="email" className="block text-sm font-medium text-white">
+          Email
+        </label>
+        <input
+          id="email"
+          ref={emailInputRef}
+          type="text"
+          pattern="[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$"
+          value={emailValue}
+          onChange={(e) => setEmailValue(e.target.value)}
+          onFocus={handleEmailFocus}
+          onBlur={() => setIsEmailFocused(false)}
+          className="w-full px-4 py-3 text-gray-800 transition-all duration-200 bg-white border-0 rounded-lg shadow-md focus:ring-2 focus:ring-blue-400 focus:outline-none"
+          placeholder="hello@example.com"
+        />
+      </div>
+      <div className="space-y-2">
+        <label htmlFor="password" className="block text-sm font-medium text-white">
+          Password
+        </label>
+        <div className="relative">
+          <input
+            id="password"
+            type={isPasswordVisible ? 'text' : 'password'}
+            value={passwordValue}
+            onChange={(e) => setPasswordValue(e.target.value)}
+            onFocus={() => setIsPasswordFocused(true)}
+            onBlur={() => setIsPasswordFocused(false)}
+            className="w-full px-4 py-3 text-gray-800 transition-all duration-200 bg-white border-0 rounded-lg shadow-md focus:ring-2 focus:ring-blue-400 focus:outline-none"
+            placeholder="••••••••"
+          />
+          <button
+            type="button"
+            onMouseDown={togglePasswordVisibility}
+            className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-500 hover:text-gray-700 focus:outline-none"
+          >
+            {isPasswordVisible ? (
+              <EyeSlashIcon className="w-5 h-5" />
+            ) : (
+              <EyeIcon className="w-5 h-5" />
+            )}
+          </button>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <label htmlFor="confirmPassword" className="block text-sm font-medium text-white">
+          Confirm Password
+        </label>
+        <div className="relative">
+          <input
+            id="confirmPassword"
+            type={isConfirmPasswordVisible ? 'text' : 'password'}
+            value={confirmPasswordValue}
+            onChange={(e) => setConfirmPasswordValue(e.target.value)}
+            onFocus={() => setIsConfirmPasswordFocused(true)}
+            onBlur={() => setIsConfirmPasswordFocused(false)}
+            className="w-full px-4 py-3 text-gray-800 transition-all duration-200 bg-white border-0 rounded-lg shadow-md focus:ring-2 focus:ring-blue-400 focus:outline-none"
+            placeholder="••••••••"
+          />
+          <button
+            type="button"
+            onMouseDown={toggleConfirmPasswordVisibility}
+            className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-500 hover:text-gray-700 focus:outline-none"
+          >
+            {isConfirmPasswordVisible ? (
+              <EyeSlashIcon className="w-5 h-5" />
+            ) : (
+              <EyeIcon className="w-5 h-5" />
+            )}
+          </button>
+        </div>
+      </div>
+      <button
+        type="submit"
+        className="w-full py-3 mt-8 text-white transition-all duration-200 transform bg-green-600 rounded-lg shadow-lg hover:bg-green-700 hover:scale-[1.02] active:scale-[0.98]"
+      >
+        Register
+      </button>
+      <button
+        type="button"
+        onClick={handleLogin}
+        className="w-full py-3 text-white transition-all duration-200 transform bg-blue-600 rounded-lg shadow-lg hover:bg-blue-700 hover:scale-[1.02] active:scale-[0.98]"
+      >
+        Back to Login
+      </button>
+    </form>
+  );
+}
+
+export default RegisterForm;
+

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -1,179 +1,85 @@
-import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { useAuth } from '../hooks/useAuth';
+import React, { useEffect, useState } from 'react';
+import { RegisterForm } from '../components/bear/RegisterForm';
+import { CartoonBear } from '../components/bear/CartoonBear';
 
 const Register = () => {
-  const [formData, setFormData] = useState({
-    name: '',
-    email: '',
-    password: '',
-    confirmPassword: ''
-  });
-  const [error, setError] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  
-  const { register } = useAuth();
-  const navigate = useNavigate();
+  const [nameValue, setNameValue] = useState('');
+  const [emailValue, setEmailValue] = useState('');
+  const [passwordValue, setPasswordValue] = useState('');
+  const [confirmPasswordValue, setConfirmPasswordValue] = useState('');
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] = useState(false);
+  const [isEmailFocused, setIsEmailFocused] = useState(false);
+  const [isPasswordFocused, setIsPasswordFocused] = useState(false);
+  const [isConfirmPasswordFocused, setIsConfirmPasswordFocused] = useState(false);
+  const [cursorPosition, setCursorPosition] = useState(0);
 
-  const handleChange = (e) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value
-    });
-  };
+  useEffect(() => {
+    if (isEmailFocused) {
+      const emailInput = document.getElementById('email');
+      if (emailInput) {
+        setCursorPosition(emailInput.selectionStart || emailValue.length);
+      } else {
+        setCursorPosition(emailValue.length);
+      }
+    }
+  }, [emailValue, isEmailFocused]);
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    setError('');
-    
-    // Validate passwords match
-    if (formData.password !== formData.confirmPassword) {
-      setError('Passwords do not match');
-      return;
+  const calculateEyePosition = () => {
+    if (!isEmailFocused) {
+      return { x: 0, y: 0 };
     }
-    
-    // Validate password strength
-    if (formData.password.length < 6) {
-      setError('Password must be at least 6 characters');
-      return;
+    if (emailValue.length === 0) {
+      return { x: 0, y: 3 };
     }
-    
-    setIsLoading(true);
-    
-    try {
-      await register({
-        name: formData.name,
-        email: formData.email,
-        password: formData.password
-      });
-      navigate('/');
-    } catch (err) {
-      setError(err.response?.data?.message || 'Registration failed. Please try again.');
-    } finally {
-      setIsLoading(false);
-    }
+    const maxHorizontalMove = 12;
+    const horizontalPosition = Math.min(cursorPosition, 30) / 30;
+    const x = horizontalPosition * maxHorizontalMove - maxHorizontalMove / 2;
+    const y = 3;
+    return { x, y };
   };
 
   return (
-    <div className="min-h-full flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-gray-800">
-      <div className="max-w-md w-full space-y-8">
-        <div>
-          <div className="flex justify-center">
-            <svg className="h-16 w-16 text-primary-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-            </svg>
-          </div>
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900 dark:text-gray-100">Create your account</h2>
-          <p className="mt-2 text-center text-sm text-gray-600 dark:text-gray-400">
-            Or{' '}
-            <Link to="/login" className="font-medium text-primary-600 hover:text-primary-500">
-              sign in to your account
-            </Link>
-          </p>
+    <div className="flex flex-col items-center justify-start w-full min-h-screen px-6 py-12 bg-navy-800">
+      <div className="w-full max-w-md mx-auto">
+        <div className="mb-8">
+          <CartoonBear
+            eyePosition={calculateEyePosition()}
+            coverEyes={
+              (isPasswordFocused && passwordValue.length > 0) ||
+              (isConfirmPasswordFocused && confirmPasswordValue.length > 0)
+            }
+            peekingEyes={
+              (isPasswordVisible && isPasswordFocused && passwordValue.length > 0) ||
+              (isConfirmPasswordVisible &&
+                isConfirmPasswordFocused &&
+                confirmPasswordValue.length > 0)
+            }
+            mood="neutral"
+          />
         </div>
-        
-        {error && (
-          <div className="bg-red-50 border-l-4 border-red-400 p-4 dark:bg-gray-700 dark:border-red-500">
-            <div className="flex">
-              <div className="flex-shrink-0">
-                <svg className="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
-                </svg>
-              </div>
-              <div className="ml-3">
-                <p className="text-sm text-red-700 dark:text-red-400">{error}</p>
-              </div>
-            </div>
-          </div>
-        )}
-        
-        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
-          <div className="rounded-md shadow-sm -space-y-px">
-            <div>
-              <label htmlFor="name" className="sr-only">Full name</label>
-              <input
-                id="name"
-                name="name"
-                type="text"
-                autoComplete="name"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
-                placeholder="Full name"
-                value={formData.name}
-                onChange={handleChange}
-              />
-            </div>
-            <div>
-              <label htmlFor="email-address" className="sr-only">Email address</label>
-              <input
-                id="email-address"
-                name="email"
-                type="email"
-                autoComplete="email"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
-                placeholder="Email address"
-                value={formData.email}
-                onChange={handleChange}
-              />
-            </div>
-            <div>
-              <label htmlFor="password" className="sr-only">Password</label>
-              <input
-                id="password"
-                name="password"
-                type="password"
-                autoComplete="new-password"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
-                placeholder="Password"
-                value={formData.password}
-                onChange={handleChange}
-              />
-            </div>
-            <div>
-              <label htmlFor="confirmPassword" className="sr-only">Confirm password</label>
-              <input
-                id="confirmPassword"
-                name="confirmPassword"
-                type="password"
-                autoComplete="new-password"
-                required
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-400"
-                placeholder="Confirm password"
-                value={formData.confirmPassword}
-                onChange={handleChange}
-              />
-            </div>
-          </div>
-
-          <div>
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isLoading ? (
-                <span className="absolute left-0 inset-y-0 flex items-center pl-3">
-                  <svg className="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                  </svg>
-                </span>
-              ) : (
-                <span className="absolute left-0 inset-y-0 flex items-center pl-3">
-                  <svg className="h-5 w-5 text-primary-500 group-hover:text-primary-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                    <path fillRule="evenodd" d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z" clipRule="evenodd" />
-                  </svg>
-                </span>
-              )}
-              {isLoading ? 'Creating account...' : 'Create account'}
-            </button>
-          </div>
-        </form>
+        <h1 className="mb-8 text-3xl font-bold text-center text-white">Create Account</h1>
+        <RegisterForm
+          nameValue={nameValue}
+          emailValue={emailValue}
+          passwordValue={passwordValue}
+          confirmPasswordValue={confirmPasswordValue}
+          isPasswordVisible={isPasswordVisible}
+          isConfirmPasswordVisible={isConfirmPasswordVisible}
+          setNameValue={setNameValue}
+          setEmailValue={setEmailValue}
+          setPasswordValue={setPasswordValue}
+          setConfirmPasswordValue={setConfirmPasswordValue}
+          setIsPasswordVisible={setIsPasswordVisible}
+          setIsConfirmPasswordVisible={setIsConfirmPasswordVisible}
+          setIsEmailFocused={setIsEmailFocused}
+          setIsPasswordFocused={setIsPasswordFocused}
+          setIsConfirmPasswordFocused={setIsConfirmPasswordFocused}
+        />
       </div>
     </div>
   );
 };
 
 export default Register;
+


### PR DESCRIPTION
## Summary
- add animated register form with bear mascot
- mirror login screen layout for registration

## Testing
- `cd client && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6895f4412734833290b5971e4f1190fe