### PR TITLE
Refine light mode palette and improve theme toggle

### DIFF
--- a/client/src/components/chat/ChatArea.js
+++ b/client/src/components/chat/ChatArea.js
@@ -146,11 +146,11 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
   };
 
   return (
-    <div className="flex-1 flex flex-col h-full bg-gray-50 dark:bg-gray-700">
+    <div className="flex-1 flex flex-col h-full bg-gray-100 dark:bg-gray-700">
       {selectedChat ? (
         <>
           {/* Chat Header */}
-          <div className="bg-white dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600 px-4 py-3 flex items-center justify-between">
+          <div className="bg-gray-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600 px-4 py-3 flex items-center justify-between">
             <div className="flex items-center">
               <button
                 onClick={toggleMobileMenu}
@@ -242,7 +242,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
           )}
           
           {/* Message Input */}
-          <div className="border-t border-gray-200 dark:border-gray-600 p-4 bg-white dark:bg-gray-700">
+          <div className="border-t border-gray-200 dark:border-gray-600 p-4 bg-gray-50 dark:bg-gray-700">
             <MessageInput 
               chatId={selectedChat._id} 
               onTyping={handleTyping} 
@@ -250,7 +250,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
           </div>
         </>
       ) : (
-        <div className="flex flex-col items-center justify-center h-full bg-gray-50 dark:bg-gray-700 p-4">
+        <div className="flex flex-col items-center justify-center h-full bg-gray-100 dark:bg-gray-700 p-4">
           <svg xmlns="http://www.w3.org/2000/svg" className="h-24 w-24 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
           </svg>

--- a/client/src/components/chat/ChatList.js
+++ b/client/src/components/chat/ChatList.js
@@ -79,7 +79,7 @@ const ChatList = ({ chats, openUserProfileModal }) => {
         return (
           <div
             key={chat._id}
-            className={`p-4 cursor-pointer bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 ${isSelected ? 'bg-gray-100 dark:bg-gray-600' : ''}`}
+            className={`p-4 cursor-pointer bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 ${isSelected ? 'bg-gray-100 dark:bg-gray-600' : ''}`}
             onClick={() => setSelectedChat(chat)}
           >
             <div className="flex items-center">

--- a/client/src/components/chat/Sidebar.js
+++ b/client/src/components/chat/Sidebar.js
@@ -81,7 +81,7 @@ const Sidebar = ({
 
   return (
     <div
-      className={`w-full md:w-80 bg-white dark:bg-gray-700 border-r border-gray-200 dark:border-gray-600 flex flex-col h-full ${isMobileMenuOpen ? 'block' : 'hidden md:flex'}`}
+      className={`w-full md:w-80 bg-gray-50 dark:bg-gray-700 border-r border-gray-200 dark:border-gray-600 flex flex-col h-full ${isMobileMenuOpen ? 'block' : 'hidden md:flex'}`}
     >
       {/* Header */}
       <div className="p-4 border-b border-gray-200 dark:border-gray-600 flex items-center justify-between">
@@ -133,7 +133,7 @@ const Sidebar = ({
             ) : (
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5 text-gray-600"
+                className="h-5 w-5 text-gray-800"
                 viewBox="0 0 20 20"
                 fill="currentColor"
               >

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -7,7 +7,7 @@
     @apply h-full;
   }
   body {
-    @apply h-full bg-gray-50 text-gray-900 antialiased dark:bg-gray-800 dark:text-gray-100;
+    @apply h-full bg-gray-100 text-gray-900 antialiased dark:bg-gray-800 dark:text-gray-100;
   }
   #root {
     @apply h-full;


### PR DESCRIPTION
## Summary
- soften light mode backgrounds to light gray for a less bright appearance
- dark mode toggle icon now uses darker gray for visibility in light mode

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689758fa58348332a081df8b811465a9