### PR TITLE
Refine light mode palette and improve theme toggle

### DIFF
--- a/client/src/components/chat/ChatArea.js
+++ b/client/src/components/chat/ChatArea.js
@@ -146,15 +146,15 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
   };
 
   return (
-    <div className="flex-1 flex flex-col h-full bg-gray-50 dark:bg-gray-700">
+    <div className="flex-1 flex flex-col h-full bg-gray-200 dark:bg-gray-700">
       {selectedChat ? (
         <>
           {/* Chat Header */}
-          <div className="bg-white dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600 px-4 py-3 flex items-center justify-between">
+          <div className="bg-gray-100 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600 px-4 py-3 flex items-center justify-between">
             <div className="flex items-center">
               <button
                 onClick={toggleMobileMenu}
-                className="md:hidden p-2 mr-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"
+                className="md:hidden p-2 mr-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700"
                 aria-label="Menu"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -177,7 +177,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
               {selectedChat.isGroupChat ? (
                 <button
                   onClick={openGroupInfoModal}
-                  className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"
+                  className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700"
                   aria-label="Group"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -194,7 +194,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
                       openUserProfileModal(otherUser);
                     }
                   }}
-                  className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"
+                  className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700"
                   aria-label="User Info"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -242,7 +242,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
           )}
           
           {/* Message Input */}
-          <div className="border-t border-gray-200 dark:border-gray-600 p-4 bg-white dark:bg-gray-700">
+          <div className="border-t border-gray-200 dark:border-gray-600 p-4 bg-gray-100 dark:bg-gray-700">
             <MessageInput 
               chatId={selectedChat._id} 
               onTyping={handleTyping} 
@@ -250,7 +250,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
           </div>
         </>
       ) : (
-        <div className="flex flex-col items-center justify-center h-full bg-gray-50 dark:bg-gray-700 p-4">
+        <div className="flex flex-col items-center justify-center h-full bg-gray-200 dark:bg-gray-700 p-4">
           <svg xmlns="http://www.w3.org/2000/svg" className="h-24 w-24 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
           </svg>

--- a/client/src/components/chat/ChatList.js
+++ b/client/src/components/chat/ChatList.js
@@ -79,7 +79,7 @@ const ChatList = ({ chats, openUserProfileModal }) => {
         return (
           <div
             key={chat._id}
-            className={`p-4 cursor-pointer bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 ${isSelected ? 'bg-gray-100 dark:bg-gray-600' : ''}`}
+            className={`p-4 cursor-pointer bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 ${isSelected ? 'bg-gray-200 dark:bg-gray-600' : ''}`}
             onClick={() => setSelectedChat(chat)}
           >
             <div className="flex items-center">

--- a/client/src/components/chat/Sidebar.js
+++ b/client/src/components/chat/Sidebar.js
@@ -81,7 +81,7 @@ const Sidebar = ({
 
   return (
     <div
-      className={`w-full md:w-80 bg-white dark:bg-gray-700 border-r border-gray-200 dark:border-gray-600 flex flex-col h-full ${isMobileMenuOpen ? 'block' : 'hidden md:flex'}`}
+      className={`w-full md:w-80 bg-gray-200 dark:bg-gray-700 border-r border-gray-200 dark:border-gray-600 flex flex-col h-full ${isMobileMenuOpen ? 'block' : 'hidden md:flex'}`}
     >
       {/* Header */}
       <div className="p-4 border-b border-gray-200 dark:border-gray-600 flex items-center justify-between">
@@ -99,7 +99,7 @@ const Sidebar = ({
         <div className="flex">
           <button
             onClick={openProfileModal}
-            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-600"
+            className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600"
             aria-label="Profile"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -109,7 +109,7 @@ const Sidebar = ({
           </button>
           <button
             onClick={handleLogout}
-            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-600 ml-1"
+            className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 ml-1"
             aria-label="Logout"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -118,7 +118,7 @@ const Sidebar = ({
           </button>
           <button
             onClick={toggleTheme}
-            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-600 ml-1"
+            className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 ml-1"
             aria-label="Toggle theme"
           >
             {theme === 'dark' ? (
@@ -130,20 +130,22 @@ const Sidebar = ({
               >
                 <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4.22 2.22a1 1 0 011.42 0l.7.7a1 1 0 11-1.42 1.42l-.7-.7a1 1 0 010-1.42zM17 9a1 1 0 100 2h1a1 1 0 100-2h-1zM4.22 4.22a1 1 0 00-1.42 1.42l.7.7a1 1 0 001.42-1.42l-.7-.7zM3 9a1 1 0 100 2H2a1 1 0 100-2h1zm1.22 6.78a1 1 0 011.42 0l.7.7a1 1 0 01-1.42 1.42l-.7-.7a1 1 0 010-1.42zM10 17a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zm6.78-1.22a1 1 0 00-1.42-1.42l-.7.7a1 1 0 001.42 1.42l.7-.7zM10 5a5 5 0 100 10 5 5 0 000-10z" />
               </svg>
-            ) : (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5 text-gray-600"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path d="M17.293 13.293a8 8 0 01-11.586-11.586 8 8 0 1011.586 11.586z" />
-              </svg>
-            )}
+              ) : (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-5 w-5 text-gray-900"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />
+                </svg>
+              )}
           </button>
           <button
             onClick={toggleMobileMenu}
-            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-600 ml-1 md:hidden"
+            className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 ml-1 md:hidden"
             aria-label="Close menu"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -7,7 +7,7 @@
     @apply h-full;
   }
   body {
-    @apply h-full bg-gray-50 text-gray-900 antialiased dark:bg-gray-800 dark:text-gray-100;
+    @apply h-full bg-gray-200 text-gray-900 antialiased dark:bg-gray-800 dark:text-gray-100;
   }
   #root {
     @apply h-full;


### PR DESCRIPTION
## Summary
- darken light mode backgrounds with gray-200 base and softer gray accents in chat panels
- theme toggle now shows a dark moon outline in light mode for better visibility

## Testing
- `npm test -- --watchAll=false --passWithNoTests` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689758fa58348332a081df8b811465a9