### PR TITLE
Refactor chat layout for Telegram look

### DIFF
--- a/client/src/components/chat/ChatArea.js
+++ b/client/src/components/chat/ChatArea.js
@@ -147,7 +147,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
 
   if (!selectedChat) {
     return (
-      <div className="flex-1 flex flex-col h-full bg-gray-200 dark:bg-gray-700">
+      <div className="chat-shell">
         <div className="flex flex-col items-center justify-center h-full bg-gray-200 dark:bg-gray-700 p-4">
           <svg xmlns="http://www.w3.org/2000/svg" className="h-24 w-24 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
@@ -168,7 +168,7 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
   }
 
   return (
-<div className="flex-1 flex flex-col h-full bg-gray-200 dark:bg-gray-700">
+<div className="chat-shell">
           {/* Chat Header */}
           <div className="bg-gray-100 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600 px-4 py-3 flex items-center justify-between">
             <div className="flex items-center">
@@ -226,41 +226,41 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
           </div>
           
           {/* Messages */}
-          <div className="flex-1 overflow-y-auto overflow-x-hidden p-4">
-            {messageLoading ? (
-              <div className="flex justify-center items-center h-full">
-                <LoadingSpinner />
-              </div>
-            ) : messages.length === 0 ? (
-              <div className="flex flex-col items-center justify-center h-full text-gray-500 dark:text-gray-400">
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-16 w-16 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                </svg>
-                <p className="mt-4 text-lg">No messages yet</p>
-                <p className="text-sm">Send a message to start the conversation</p>
-              </div>
-            ) : (
-              <MessageList 
-                messages={messages} 
-                currentUser={currentUser} 
-                selectedChat={selectedChat} 
-              />
-            )}
-            <div ref={messagesEndRef} />
-          </div>
-          
-          {/* Typing Indicator */}
-          {getTypingText() && (
-            <div className="px-4 py-2">
-              <div className="typing-indicator text-gray-500 dark:text-gray-400 text-sm">
-                {getTypingText()}
-                <span></span>
-                <span></span>
-                <span></span>
-              </div>
+          <div className="chat-scroll">
+            <div className="chat-column">
+              {messageLoading ? (
+                <div className="flex justify-center items-center h-full">
+                  <LoadingSpinner />
+                </div>
+              ) : messages.length === 0 ? (
+                <div className="flex flex-col items-center justify-center h-full text-gray-500 dark:text-gray-400">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-16 w-16 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                  </svg>
+                  <p className="mt-4 text-lg">No messages yet</p>
+                  <p className="text-sm">Send a message to start the conversation</p>
+                </div>
+              ) : (
+                <MessageList
+                  messages={messages}
+                  currentUser={currentUser}
+                  selectedChat={selectedChat}
+                />
+              )}
+
+              {getTypingText() && (
+                <div className="typing-indicator text-gray-500 dark:text-gray-400 text-sm">
+                  {getTypingText()}
+                  <span></span>
+                  <span></span>
+                  <span></span>
+                </div>
+              )}
+
+              <div ref={messagesEndRef} />
             </div>
-          )}
-          
+          </div>
+
           {/* Message Input */}
             <div className="border-t border-gray-200 dark:border-gray-600 p-4 bg-gray-100 dark:bg-gray-700">
               <MessageInput chatId={selectedChat._id} onTyping={handleTyping} />

--- a/client/src/components/chat/MessageList.js
+++ b/client/src/components/chat/MessageList.js
@@ -145,107 +145,89 @@ const handleDeleteMessage = async (messageId, scope) => {
       <div className="space-y-6">
         {Object.keys(groupedMessages).map((date) => (
           <div key={date}>
-            <div className="flex justify-center mb-4">
-              <div className="bg-gray-200 rounded-full px-3 py-1 text-xs text-gray-600 dark:bg-gray-600 dark:text-gray-200">
-                {formatDate(date)}
-              </div>
+            <div className="date-separator">
+              <span>{formatDate(date)}</span>
             </div>
 
-            <div className="space-y-2">
-              {groupedMessages[date].map((message) => {
+            {groupedMessages[date].map((message, index, arr) => {
               const isSentByMe = message.sender._id === currentUser._id;
-              
+              const previous = arr[index - 1];
+              const isSameSender = previous && previous.sender._id === message.sender._id;
+              const gapClass = index === 0 ? '' : isSameSender ? 'mt-1' : 'mt-3';
+
               return (
-                <div key={message._id} className={`flex ${isSentByMe ? 'justify-end' : 'justify-start'}`}>
-                  <div className="flex max-w-[75%]">
-                    {!isSentByMe && !selectedChat.isGroupChat && (
-                      <img 
-                        src={message.sender.avatar || `https://ui-avatars.com/api/?name=${encodeURIComponent(message.sender.name)}&background=random`} 
-                        alt={message.sender.name}
-                        className="h-8 w-8 rounded-full mr-2 mt-1"
-                      />
+                <div key={message._id} className={`message-row ${isSentByMe ? 'outgoing' : 'incoming'} ${gapClass}`}>
+                  {!isSentByMe && !selectedChat.isGroupChat && (
+                    <img
+                      src={message.sender.avatar || `https://ui-avatars.com/api/?name=${encodeURIComponent(message.sender.name)}&background=random`}
+                      alt={message.sender.name}
+                      className="h-8 w-8 rounded-full mr-2 mt-1"
+                    />
+                  )}
+
+                  <div>
+                    {selectedChat.isGroupChat && !isSentByMe && (
+                      <div className="flex items-center mb-1">
+                        <img
+                          src={message.sender.avatar || `https://ui-avatars.com/api/?name=${encodeURIComponent(message.sender.name)}&background=random`}
+                          alt={message.sender.name}
+                          className="h-6 w-6 rounded-full mr-2"
+                        />
+                        <span className="text-xs font-medium text-gray-700">{message.sender.name}</span>
+                      </div>
                     )}
-                    
-                    <div>
-                      {selectedChat.isGroupChat && !isSentByMe && (
-                        <div className="flex items-center mb-1">
-                          <img 
-                            src={message.sender.avatar || `https://ui-avatars.com/api/?name=${encodeURIComponent(message.sender.name)}&background=random`} 
-                            alt={message.sender.name}
-                            className="h-6 w-6 rounded-full mr-2"
-                          />
-                          <span className="text-xs font-medium text-gray-700">{message.sender.name}</span>
+
+                    <div dir="auto" className={`bubble ${isSentByMe ? 'outgoing' : 'incoming'}`}>
+                      {message.content && (
+                        <div className="whitespace-pre-line break-words">
+                          {message.content}
                         </div>
                       )}
-                      
-                      <div
-                        className={`message-bubble ${isSentByMe ? 'sent' : 'received'}`}
-                      >
-                        {message.content && (
-                          <div className="whitespace-pre-line break-words">
-                            {message.content}
-                          </div>
-                        )}
 
-                        {message.attachments && message.attachments.length > 0 && (
-                          <div className="space-y-2">
-                            {message.attachments.map((attachment, index) => (
-                              <div key={index}>
-                                {renderAttachment(attachment)}
-                              </div>
-                            ))}
-                          </div>
-                        )}
+                      {message.attachments && message.attachments.length > 0 && (
+                        <div className="space-y-2">
+                          {message.attachments.map((attachment, index) => (
+                            <div key={index}>{renderAttachment(attachment)}</div>
+                          ))}
+                        </div>
+                      )}
 
-                        <div className="timestamp">{formatTime(message.createdAt)}</div>
-                      </div>
-
-                      <div className="flex items-center mt-1">
-                        
+                      <div className="meta">
+                        {formatTime(message.createdAt)}
                         {isSentByMe && (
-                          <>
-                            <span className="mx-1 text-gray-400 dark:text-gray-500">•</span>
-                            {message.readBy.length > 0 ? (
-                              <span className="text-xs text-gray-500 dark:text-gray-400">
-                                Read
-                              </span>
-                            ) : (
-                              <span className="text-xs text-gray-500 dark:text-gray-400">
-                                Delivered
-                              </span>
-                            )}
-                          </>
+                          <span className="ml-1">
+                            {message.readBy.length > 0 ? 'Read' : 'Delivered'}
+                          </span>
                         )}
-                        
-                        <button
-                          onClick={() => openDeleteModal(message._id)}
-                          className="ml-2 text-gray-400 hover:text-red-500"
-                          aria-label="Delete message"
-                        >
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            className="h-3 w-3"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                            />
-                          </svg>
-                        </button>
                       </div>
                     </div>
                   </div>
+
+                  <button
+                    onClick={() => openDeleteModal(message._id)}
+                    className="ml-2 text-gray-400 hover:text-red-500"
+                    aria-label="Delete message"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="h-3 w-3"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                      />
+                    </svg>
+                  </button>
                 </div>
               );
             })}
           </div>
-        </div>
-      ))}
+        ))}
       </div>
       <ImageModal
         isOpen={!!selectedImage}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2,12 +2,36 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --chat-bg: #f5f5f5;
+  --bubble-incoming-bg: #f1f1f1;
+  --bubble-incoming-color: #000;
+  --bubble-outgoing-bg: #4fa3f7;
+  --bubble-outgoing-color: #fff;
+  --timestamp-color: rgba(0,0,0,0.45);
+  --date-pill-bg: #e0e0e0;
+  --date-pill-color: #555;
+}
+
+.dark {
+  --chat-bg: #1f1f1f;
+  --bubble-incoming-bg: #2A2F32;
+  --bubble-incoming-color: #e0e0e0;
+  --bubble-outgoing-bg: #4fa3f7;
+  --bubble-outgoing-color: #fff;
+  --timestamp-color: rgba(255,255,255,0.55);
+  --date-pill-bg: #3a3a3a;
+  --date-pill-color: #ddd;
+}
+
 @layer base {
   html {
     @apply h-full;
   }
   body {
-    @apply h-full bg-gray-200 text-gray-900 antialiased dark:bg-gray-800 dark:text-gray-100;
+    @apply h-full antialiased;
+    background: var(--chat-bg);
+    color: var(--bubble-incoming-color);
   }
   #root {
     @apply h-full;
@@ -57,28 +81,72 @@
   @apply bg-gray-600 rounded hover:bg-gray-500;
 }
 
-/* Message bubble styles */
-.message-bubble {
-/* extra padding on the bottom-right so the timestamp fits without overlapping */
-  @apply relative max-w-[75%] pl-3 pr-9 pt-2 pb-5 mb-1 rounded-lg break-words whitespace-pre-line shadow;
+/* Chat layout */
+.chat-shell {
+  @apply flex flex-col h-full;
+  background: var(--chat-bg);
 }
 
-.message-bubble.sent {
-  background-color: #4fa3f7;
-  @apply text-white ml-auto rounded-br-none;
+.chat-scroll {
+  @apply flex-1 overflow-y-auto overflow-x-hidden;
 }
 
-.message-bubble.received {
-  @apply mr-auto rounded-bl-none text-gray-900 bg-gray-100 dark:text-gray-100;
-  background-color: #f1f1f1;
+.chat-column {
+  @apply w-full mx-auto;
+  max-width: 720px;
+  padding: 16px;
 }
 
-.dark .message-bubble.received {
-  background-color: #2A2F32;
+/* Message styles */
+.message-row {
+  @apply flex w-full;
 }
 
-.message-bubble .timestamp {
-  @apply absolute bottom-1 right-2 text-[10px] text-gray-400;
+.message-row.incoming {
+  @apply justify-start;
+}
+
+.message-row.outgoing {
+  @apply justify-end;
+}
+
+.bubble {
+  @apply relative break-words whitespace-pre-line shadow;
+  max-width: 75%;
+  padding: 8px 12px 14px 12px;
+}
+
+.bubble.incoming {
+  background: var(--bubble-incoming-bg);
+  color: var(--bubble-incoming-color);
+  border-radius: 18px 18px 18px 6px;
+}
+
+.bubble.outgoing {
+  background: var(--bubble-outgoing-bg);
+  color: var(--bubble-outgoing-color);
+  border-radius: 18px 18px 6px 18px;
+}
+
+.bubble .meta {
+  position: absolute;
+  right: 8px;
+  bottom: 4px;
+  font-size: 10px;
+  opacity: 0.7;
+  color: var(--timestamp-color);
+}
+
+/* Date separator */
+.date-separator {
+  @apply flex justify-center my-3 text-xs;
+}
+
+.date-separator span {
+  background: var(--date-pill-bg);
+  color: var(--date-pill-color);
+  padding: 2px 8px;
+  border-radius: 9999px;
 }
 
 /* Typing indicator animation */


### PR DESCRIPTION
## Summary
- center conversation in responsive column and add chat shell wrappers
- redesign message bubbles with CSS variables, rounded corners, and in-bubble timestamps
- group messages with dynamic spacing and styled date separators

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68976235eb2883328001f146e91bc7c0