### PR TITLE
feat: align chat UI with Telegram layout

### DIFF
--- a/client/src/components/chat/ChatArea.js
+++ b/client/src/components/chat/ChatArea.js
@@ -262,9 +262,11 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
           </div>
 
           {/* Message Input */}
-            <div className="border-t border-gray-200 dark:border-gray-600 p-4 bg-gray-100 dark:bg-gray-700">
+          <div className="border-t border-gray-200 dark:border-gray-600 bg-gray-100 dark:bg-gray-700">
+            <div className="chat-column">
               <MessageInput chatId={selectedChat._id} onTyping={handleTyping} />
             </div>
+          </div>
       </div>
     );
   };

--- a/client/src/components/chat/MessageInput.js
+++ b/client/src/components/chat/MessageInput.js
@@ -175,7 +175,7 @@ const MessageInput = ({ chatId, onTyping }) => {
   };
 
   return (
-    <div className="p-4 border-t border-gray-200 dark:border-gray-600">
+    <div className="py-3">
       {/* Attachment previews */}
       {attachments.length > 0 && (
         <div className="flex flex-wrap gap-2 mb-3">

--- a/client/src/components/chat/MessageList.js
+++ b/client/src/components/chat/MessageList.js
@@ -153,20 +153,25 @@ const handleDeleteMessage = async (messageId, scope) => {
               const isSentByMe = message.sender._id === currentUser._id;
               const previous = arr[index - 1];
               const isSameSender = previous && previous.sender._id === message.sender._id;
+              const isFirstOfSender = !isSameSender;
               const gapClass = index === 0 ? '' : isSameSender ? 'mt-1' : 'mt-3';
 
               return (
                 <div key={message._id} className={`message-row ${isSentByMe ? 'outgoing' : 'incoming'} ${gapClass}`}>
                   {!isSentByMe && !selectedChat.isGroupChat && (
-                    <img
-                      src={message.sender.avatar || `https://ui-avatars.com/api/?name=${encodeURIComponent(message.sender.name)}&background=random`}
-                      alt={message.sender.name}
-                      className="h-8 w-8 rounded-full mr-2 mt-1"
-                    />
+                    isFirstOfSender ? (
+                      <img
+                        src={message.sender.avatar || `https://ui-avatars.com/api/?name=${encodeURIComponent(message.sender.name)}&background=random`}
+                        alt={message.sender.name}
+                        className="h-8 w-8 rounded-full mr-2 self-end"
+                      />
+                    ) : (
+                      <div className="w-8 mr-2" />
+                    )
                   )}
 
                   <div>
-                    {selectedChat.isGroupChat && !isSentByMe && (
+                    {selectedChat.isGroupChat && !isSentByMe && isFirstOfSender && (
                       <div className="flex items-center mb-1">
                         <img
                           src={message.sender.avatar || `https://ui-avatars.com/api/?name=${encodeURIComponent(message.sender.name)}&background=random`}
@@ -179,7 +184,7 @@ const handleDeleteMessage = async (messageId, scope) => {
 
                     <div dir="auto" className={`bubble ${isSentByMe ? 'outgoing' : 'incoming'}`}>
                       {message.content && (
-                        <div className="whitespace-pre-line break-words">
+                        <div>
                           {message.content}
                         </div>
                       )}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -99,7 +99,7 @@
 
 /* Message styles */
 .message-row {
-  @apply flex w-full;
+  @apply flex w-full items-end;
 }
 
 .message-row.incoming {
@@ -111,7 +111,7 @@
 }
 
 .bubble {
-  @apply relative break-words whitespace-pre-line shadow;
+  @apply relative inline-block break-words whitespace-pre-wrap shadow;
   max-width: 75%;
   padding: 8px 12px 14px 12px;
 }


### PR DESCRIPTION
## Summary
- center message column and input bar with Telegram-style bubble widths and spacing
- group consecutive messages with reduced gaps and optional avatars for first message only
- remove internal border on message input so it aligns cleanly with the chat column

## Testing
- `npm test --prefix client -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689766770e948332a360113d7ae64dd8