### PR TITLE
feat: modernize chat interface design

### DIFF
--- a/client/src/components/chat/ChatArea.js
+++ b/client/src/components/chat/ChatArea.js
@@ -147,18 +147,18 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
 
   if (!selectedChat) {
     return (
-      <div className="chat-shell">
-        <div className="flex flex-col items-center justify-center h-full bg-gray-200 dark:bg-gray-700 p-4">
+      <div key="placeholder" className="chat-shell">
+        <div className="flex flex-col items-center justify-center h-full bg-gray-200 dark:bg-gray-700 p-4 text-center">
           <svg xmlns="http://www.w3.org/2000/svg" className="h-24 w-24 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
           </svg>
           <h2 className="mt-4 text-xl font-semibold text-gray-700 dark:text-gray-100">Welcome to LiveChat</h2>
-          <p className="mt-2 text-gray-500 dark:text-gray-400 text-center max-w-md">
+          <p className="mt-2 text-gray-500 dark:text-gray-400 max-w-md">
             Select a chat from the sidebar or search for users to start a new conversation.
           </p>
           <button
             onClick={toggleMobileMenu}
-            className="mt-6 md:hidden inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+            className="mt-6 md:hidden inline-flex items-center px-4 py-2 text-sm font-semibold rounded-lg text-white bg-gradient-to-r from-primary-500 to-primary-700 shadow-md hover:shadow-lg transition"
           >
             Open Chats
           </button>
@@ -168,22 +168,22 @@ const ChatArea = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal }
   }
 
   return (
-<div className="chat-shell">
+    <div key={selectedChat._id} className="chat-shell">
           {/* Chat Header */}
-          <div className="bg-gray-100 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600 px-4 py-3 flex items-center justify-between">
+          <div className="bg-gray-100 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600 px-4 py-3 flex items-center justify-between shadow-sm">
             <div className="flex items-center">
               <button
                 onClick={toggleMobileMenu}
                 className="md:hidden p-2 mr-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700"
-                aria-label="Menu"
+                aria-label="Back"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
                 </svg>
               </button>
               <div className="flex items-center cursor-pointer" onClick={handleProfileClick}>
-                <img 
-                  src={getChatAvatar()} 
+                <img
+                  src={getChatAvatar()}
                   alt={getChatName()}
                   className="h-10 w-10 rounded-full object-cover"
                 />

--- a/client/src/components/chat/ChatList.js
+++ b/client/src/components/chat/ChatList.js
@@ -79,7 +79,7 @@ const ChatList = ({ chats, openUserProfileModal }) => {
         return (
           <div
             key={chat._id}
-            className={`p-4 cursor-pointer bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 ${isSelected ? 'bg-gray-200 dark:bg-gray-600' : ''}`}
+            className={`p-4 cursor-pointer rounded-lg transition-colors duration-200 bg-gray-100 dark:bg-gray-700 hover:shadow-md hover:bg-gray-200 dark:hover:bg-gray-600 ${isSelected ? 'bg-gray-200 dark:bg-gray-600 shadow' : ''}`}
             onClick={() => setSelectedChat(chat)}
           >
             <div className="flex items-center">

--- a/client/src/components/chat/Sidebar.js
+++ b/client/src/components/chat/Sidebar.js
@@ -81,7 +81,7 @@ const Sidebar = ({
 
   return (
     <div
-      className={`w-full md:w-80 bg-gray-200 dark:bg-gray-700 border-r border-gray-200 dark:border-gray-600 flex flex-col h-full ${isMobileMenuOpen ? 'block' : 'hidden md:flex'}`}
+      className={`fixed md:static inset-y-0 left-0 z-30 transform ${isMobileMenuOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0 transition-transform duration-300 w-64 md:w-80 bg-gradient-to-b from-gray-100 to-gray-200 dark:from-gray-800 dark:to-gray-700 border-r border-gray-200 dark:border-gray-600 flex flex-col h-full shadow-lg`}
     >
       {/* Header */}
       <div className="p-4 border-b border-gray-200 dark:border-gray-600 flex items-center justify-between">
@@ -198,9 +198,9 @@ const Sidebar = ({
       
       {/* Create Group Button */}
       <div className="px-4 py-2">
-        <button 
+        <button
           onClick={openCreateGroupModal}
-          className="w-full flex items-center justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+          className="w-full flex items-center justify-center py-3 px-4 text-sm font-semibold rounded-lg text-white bg-gradient-to-r from-primary-500 to-primary-700 shadow-md hover:shadow-lg transition"
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -3,10 +3,11 @@
 @tailwind utilities;
 
 :root {
-  --chat-bg: #f5f5f5;
-  --bubble-incoming-bg: #f1f1f1;
+  /* Modern gradient background and refined bubble palette */
+  --chat-bg: linear-gradient(135deg, #fdfbfb 0%, #ebedee 100%);
+  --bubble-incoming-bg: #ffffff;
   --bubble-incoming-color: #000;
-  --bubble-outgoing-bg: #4fa3f7;
+  --bubble-outgoing-bg: linear-gradient(135deg, #0ea5e9 0%, #3b82f6 100%);
   --bubble-outgoing-color: #fff;
   --timestamp-color: rgba(0,0,0,0.45);
   --date-pill-bg: #e0e0e0;
@@ -14,10 +15,10 @@
 }
 
 .dark {
-  --chat-bg: #1f1f1f;
+  --chat-bg: linear-gradient(135deg, #1f2937 0%, #111827 100%);
   --bubble-incoming-bg: #2A2F32;
   --bubble-incoming-color: #e0e0e0;
-  --bubble-outgoing-bg: #4fa3f7;
+  --bubble-outgoing-bg: linear-gradient(135deg, #0ea5e9 0%, #3b82f6 100%);
   --bubble-outgoing-color: #fff;
   --timestamp-color: rgba(255,255,255,0.55);
   --date-pill-bg: #3a3a3a;
@@ -29,7 +30,7 @@
     @apply h-full;
   }
   body {
-    @apply h-full antialiased;
+    @apply h-full antialiased font-sans;
     background: var(--chat-bg);
     color: var(--bubble-incoming-color);
   }
@@ -83,7 +84,7 @@
 
 /* Chat layout */
 .chat-shell {
-  @apply flex flex-col h-full;
+  @apply flex flex-col h-full flex-1 transition-all duration-300;
   background: var(--chat-bg);
 }
 

--- a/client/src/pages/Chat.js
+++ b/client/src/pages/Chat.js
@@ -67,9 +67,16 @@ const Chat = () => {
   };
 
   return (
-    <div className="h-full flex">
+    <div className="h-full flex relative">
+      {isMobileMenuOpen && (
+        <div
+          className="fixed inset-0 bg-black/40 z-20 md:hidden transition-opacity"
+          onClick={toggleMobileMenu}
+        ></div>
+      )}
+
       {/* Sidebar */}
-      <Sidebar 
+      <Sidebar
         isMobileMenuOpen={isMobileMenuOpen}
         toggleMobileMenu={toggleMobileMenu}
         openProfileModal={openProfileModal}
@@ -78,7 +85,7 @@ const Chat = () => {
       />
 
       {/* Chat Area */}
-      <ChatArea 
+      <ChatArea
         toggleMobileMenu={toggleMobileMenu}
         openUserProfileModal={openUserProfileModal}
         openGroupInfoModal={openGroupInfoModal}


### PR DESCRIPTION
## Summary
- apply gradient-based theme and ensure chat area fills available space
- add hover effects and slide-in responsive sidebar with prominent new group button
- improve mobile navigation with back button and overlay

## Testing
- `cd client && npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68979018a498833280f736621bead8fb