### PR TITLE
fix: prevent per-letter message wrapping

### DIFF
--- a/client/src/components/chat/MessageList.js
+++ b/client/src/components/chat/MessageList.js
@@ -220,7 +220,9 @@ const MessageList = ({ messages, currentUser, selectedChat }) => {
                           isLast ? 'bubble--tail' : ''
                         }`}
                       >
-                        {message.content && <div>{message.content}</div>}
+                        {message.content && (
+                          <div className="message-text">{message.content}</div>
+                        )}
 
                         {message.attachments && message.attachments.length > 0 && (
                           <div className="space-y-2 mt-2">

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -102,6 +102,13 @@
   max-width: 85%;
 }
 
+.message-text {
+  white-space: pre-wrap;
+  word-break: normal;
+  overflow-wrap: break-word;
+  display: inline;
+}
+
 @media (min-width: 768px) {
   .bubble {
     max-width: 70%;


### PR DESCRIPTION
## Summary
- ensure chat messages wrap on spaces using a new `.message-text` style
- apply `.message-text` to message bubbles to avoid per-letter breaks

## Testing
- `cd server && npm test` *(fails: Error: no test specified)*
- `cd client && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689797f768a8833282696369dfd8af70