### PR TITLE
fix(chat): prevent per-character line breaks; normalize bubble wrapping and width; add meta/date polish

### DIFF
--- a/client/src/components/chat/MessageList.js
+++ b/client/src/components/chat/MessageList.js
@@ -174,8 +174,11 @@ const MessageList = ({ messages, currentUser, selectedChat }) => {
         {items.map((item, idx) => {
           if (item.type === 'date') {
             return (
-              <div key={`date-${idx}`} className="date-pill">
-                <span>{formatDate(item.date)}</span>
+              <div
+                key={`date-${idx}`}
+                className="mx-auto my-3 px-3 py-1 text-xs text-slate-500 bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-full w-fit"
+              >
+                {formatDate(item.date)}
               </div>
             );
           }
@@ -213,7 +216,7 @@ const MessageList = ({ messages, currentUser, selectedChat }) => {
                 {item.messages.map((message, i) => {
                   const isLast = i === item.messages.length - 1;
                   return (
-                    <div key={message._id} className="flex items-end group">
+                    <div key={message._id} className="message-row group">
                       <div
                         dir="auto"
                         className={`bubble ${isMe ? 'bubble--me' : 'bubble--them'} ${
@@ -234,7 +237,7 @@ const MessageList = ({ messages, currentUser, selectedChat }) => {
                       </div>
                       <button
                         onClick={() => openDeleteModal(message._id)}
-                        className="ml-1 text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100"
+                        className="ml-1 text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 align-bottom"
                         aria-label="Delete message"
                       >
                         <svg
@@ -256,11 +259,15 @@ const MessageList = ({ messages, currentUser, selectedChat }) => {
                   );
                 })}
 
-                <div className={`group-meta ${isMe ? 'text-right' : 'text-left'}`}>
+                <div
+                  className={`group-meta text-xs text-slate-400 mt-1 ${
+                    isMe ? 'text-right' : 'text-left'
+                  }`}
+                >
                   {formatTime(lastMsg.createdAt)}
                   {isMe && (
                     <span className="ml-1">
-                      {lastMsg.readBy.length > 0 ? '✓✓ Read' : '✓ Delivered'}
+                      • {lastMsg.readBy.length > 0 ? '✓✓ Read' : '✓ Delivered'}
                     </span>
                   )}
                 </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -98,31 +98,44 @@
 
 /* Message styles */
 .bubble {
-  @apply relative break-words whitespace-pre-wrap shadow px-4 py-2 rounded-2xl;
+  position: relative;
+  display: inline-block;
   max-width: 85%;
+  width: auto;
+  min-width: 0;
+  padding: 10px 14px;
+  border-radius: 18px;
+  line-height: 1.25;
+  white-space: pre-wrap;
+  word-break: normal !important;
+  overflow-wrap: break-word;
 }
 
 .message-text {
-  white-space: pre-wrap;
-  word-break: normal;
-  overflow-wrap: break-word;
   display: inline;
+  white-space: inherit;
+  word-break: inherit !important;
+  overflow-wrap: inherit;
 }
 
 @media (min-width: 768px) {
   .bubble {
-    max-width: 70%;
+    max-width: 72%;
   }
 }
 
 .bubble--me {
-  background: var(--primary);
+  margin-left: auto;
   color: #fff;
+  background: #60a5fa;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
 }
 
 .bubble--them {
-  background: var(--surface);
-  color: var(--text);
+  margin-right: auto;
+  color: #0f172a;
+  background: #eaf1ff;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.04);
 }
 
 .bubble--tail::after {
@@ -136,35 +149,32 @@
 
 .bubble--me.bubble--tail::after {
   right: -8px;
-  border-left-color: var(--primary);
+  border-left-color: #60a5fa;
   border-top-width: 8px;
   border-bottom-width: 0;
 }
 
 .bubble--them.bubble--tail::after {
   left: -8px;
-  border-right-color: var(--surface);
+  border-right-color: #eaf1ff;
   border-top-width: 8px;
   border-bottom-width: 0;
 }
 
 .group-meta {
   font-size: 0.75rem;
-  color: var(--muted);
+  color: #94a3b8;
   margin-top: 4px;
 }
 
-/* Date pill */
-.date-pill {
-  @apply flex justify-center my-4 text-xs;
+.message-row {
+  display: block;
+  min-width: 0;
 }
 
-.date-pill span {
-  background: var(--surface);
-  color: var(--muted);
-  border: 1px solid var(--border);
-  padding: 2px 8px;
-  border-radius: 9999px;
+.bubble,
+.message-text {
+  word-break: keep-all !important;
 }
 
 /* Reactions and quotes placeholder classes */


### PR DESCRIPTION
## Summary
- prevent per-character line breaks by resetting bubble and text wrapping and limiting width
- refresh incoming/outgoing bubble styles with proper max widths and shadows
- polish metadata and date pill rendering in the message list

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

## Validation Checklist
- [ ] Normal words ("hello world", "test") stay on one line until bubble width is reached.
- [ ] Long URLs/verylongstrings wrap gracefully (no overflow).
- [ ] Emojis and filenames render on a single line where possible.
- [ ] Desktop: bubble max-width ≈ 72%; Mobile: increase to ≈ 85%.
- [ ] No ancestor applies word-break: break-all to bubbles/text.
- [ ] No parent grid/flex config squeezes bubbles (e.g., flex: 0 0 auto, min-width: 0 set on containers).


------
https://chatgpt.com/codex/tasks/task_e_68979aa5fd208332bf9fcc8c654cea5f