### PR TITLE
feat(chat): preserve user whitespace in messages

### DIFF
--- a/client/src/components/chat/MessageInput.js
+++ b/client/src/components/chat/MessageInput.js
@@ -110,7 +110,7 @@ const MessageInput = ({ chatId, onTyping }) => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     
-    if ((!message.trim() && attachments.length === 0) || !chatId) return;
+    if ((message === '' && attachments.length === 0) || !chatId) return;
     
     try {
       // Stop typing indicator
@@ -124,7 +124,7 @@ const MessageInput = ({ chatId, onTyping }) => {
         uploaded = await uploadAttachments(files);
       }
 
-      await sendNewMessage(chatId, message.trim(), uploaded);
+      await sendNewMessage(chatId, message, uploaded);
       
       // Reset state
       setMessage('');
@@ -233,7 +233,7 @@ const MessageInput = ({ chatId, onTyping }) => {
         <button 
           type="submit" 
           className="p-2 bg-primary-600 text-white rounded-full hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
-          disabled={!message.trim() && attachments.length === 0}
+          disabled={message === '' && attachments.length === 0}
           aria-label="Send message"
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/client/src/components/chat/MessageList.js
+++ b/client/src/components/chat/MessageList.js
@@ -65,15 +65,7 @@ const MessageList = ({ messages, currentUser, selectedChat }) => {
 
   const formatTime = (dateStr) => format(new Date(dateStr), 'h:mm a');
 
-  const formatMessageContent = (text, wordsPerLine = 7) => {
-    if (!text) return '';
-    const words = text.split(/\s+/);
-    const lines = [];
-    for (let i = 0; i < words.length; i += wordsPerLine) {
-      lines.push(words.slice(i, i + wordsPerLine).join(' '));
-    }
-    return lines.join('\n');
-  };
+  // Messages are rendered exactly as typed; wrapping handled via CSS
 
   const openDeleteModal = (messageId) => setMessageToDelete(messageId);
 
@@ -234,9 +226,9 @@ const MessageList = ({ messages, currentUser, selectedChat }) => {
                         }`}
                       >
                         {message.content && (
-                          <div className="message-text" style={{ whiteSpace: 'pre-wrap' }}>
-                            {formatMessageContent(message.content)}
-                          </div>
+                          <span className="msg-text" aria-label="message body">
+                            {message.content}
+                          </span>
                         )}
 
                         {message.attachments && message.attachments.length > 0 && (

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -105,17 +105,20 @@
   min-width: 0;
   padding: 10px 14px;
   border-radius: 18px;
-  line-height: 1.25;
-  white-space: pre-wrap;
-  word-break: normal !important;
-  overflow-wrap: break-word;
+  line-height: 1.35;
 }
 
-.message-text {
+.msg-text {
+  white-space: break-spaces;
+  word-break: normal;
+  overflow-wrap: break-word;
   display: inline;
-  white-space: inherit;
-  word-break: inherit !important;
-  overflow-wrap: inherit;
+}
+
+@supports not (white-space: break-spaces) {
+  .msg-text {
+    white-space: pre-wrap;
+  }
 }
 
 @media (min-width: 768px) {
@@ -172,10 +175,6 @@
   min-width: 0;
 }
 
-.bubble,
-.message-text {
-  word-break: keep-all !important;
-}
 
 /* Reactions and quotes placeholder classes */
 .reaction-row {

--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -25,10 +25,13 @@ const sendMessage = async (req, res) => {
       return res.status(400).json({ message: 'Chat ID is required' });
     }
 
+    // Normalize newlines but preserve all other whitespace
+    const normalizedContent = content ? content.replace(/\r\n/g, '\n') : '';
+
     // Create a new message
     const newMessage = {
       sender: req.user._id,
-      content: content || '',
+      content: normalizedContent,
       chat: chatId,
       attachments,
       readBy: [req.user._id], // Sender has read the message

--- a/server/models/message.model.js
+++ b/server/models/message.model.js
@@ -9,7 +9,6 @@ const messageSchema = new mongoose.Schema(
     },
     content: {
       type: String,
-      trim: true,
       default: ''
     },
     chat: {


### PR DESCRIPTION
## Summary
- stop trimming message content on client & server; normalize CRLF to LF only
- render chat messages with new `.msg-text` using `white-space: break-spaces`
- allow long messages to wrap without breaking words

## Testing
- `npm test --prefix client -- --watchAll=false` *(fails: No tests found)*
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897a00640688332ab3a3f7629a277be