### PR TITLE
Allow new client domain and fix email patterns

### DIFF
--- a/client/src/components/bear/LoginForm.js
+++ b/client/src/components/bear/LoginForm.js
@@ -41,7 +41,7 @@ export function LoginForm({
       return;
     }
     // Use a stricter email pattern that properly escapes hyphen characters
-    const emailRegex = /^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/;
+    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
     if (!emailRegex.test(emailValue)) {
       setErrorMessage('Please enter a valid email address');
       onLoginAttempt(false);
@@ -74,7 +74,7 @@ export function LoginForm({
           id="email"
           ref={emailInputRef}
           type="text"
-          pattern="[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$"
+          pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
           value={emailValue}
           onChange={(e) => setEmailValue(e.target.value)}
           onFocus={handleEmailFocus}

--- a/client/src/components/bear/RegisterForm.js
+++ b/client/src/components/bear/RegisterForm.js
@@ -53,7 +53,7 @@ export function RegisterForm({
       setErrorMessage('Please fill in all fields');
       return;
     }
-    const emailRegex = /^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$/;
+    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
     if (!emailRegex.test(emailValue)) {
       setErrorMessage('Please enter a valid email address');
       return;
@@ -111,7 +111,7 @@ export function RegisterForm({
           id="email"
           ref={emailInputRef}
           type="text"
-          pattern="[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$"
+          pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
           value={emailValue}
           onChange={(e) => setEmailValue(e.target.value)}
           onFocus={handleEmailFocus}

--- a/server/server.js
+++ b/server/server.js
@@ -21,12 +21,20 @@ const socketService = require('./services/socket.service');
 const app = express();
 
 // Middleware
-app.use(cors({
-  origin: process.env.NODE_ENV === 'production'
-    ? [process.env.CLIENT_URL || 'https://livechat-production-d44b.up.railway.app']
-    : 'http://localhost:3000',
-  credentials: true
-}));
+const allowedOrigins =
+  process.env.NODE_ENV === 'production'
+    ? [
+        process.env.CLIENT_URL || 'https://chatee.up.railway.app',
+        'https://livechat-production-d44b.up.railway.app',
+      ]
+    : ['http://localhost:3000'];
+
+app.use(
+  cors({
+    origin: allowedOrigins,
+    credentials: true,
+  })
+);
 app.use(express.json());
 const path = require('path');
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
@@ -60,9 +68,7 @@ const server = http.createServer(app);
 // Create Socket.IO server
 const io = socketIo(server, {
   cors: {
-    origin: process.env.NODE_ENV === 'production' 
-      ? [process.env.CLIENT_URL || 'https://livechat-production-d44b.up.railway.app'] 
-      : ['http://localhost:3000'],
+    origin: allowedOrigins,
     methods: ['GET', 'POST'],
     credentials: true
   }


### PR DESCRIPTION
## Summary
- expand CORS and socket origins to include deployed client domain
- correct email regex and pattern in login and register forms

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `CI=true npm test -- --watch=false` (client) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a2c5e27c8332bb2d0968c99096ab