### PR TITLE
Fix auth context user handling to enable login and registration

### DIFF
--- a/client/src/contexts/AuthContext.js
+++ b/client/src/contexts/AuthContext.js
@@ -41,7 +41,9 @@ export const AuthProvider = ({ children }) => {
     setError(null);
     try {
       const data = await loginUser(email, password);
-      setCurrentUser(data.user);
+      // API returns user fields directly rather than wrapping in a `user` object
+      // so store the entire response as the current user
+      setCurrentUser(data);
       setIsAuthenticated(true);
       return data;
     } catch (err) {
@@ -54,7 +56,8 @@ export const AuthProvider = ({ children }) => {
     setError(null);
     try {
       const data = await registerUser(userData);
-      setCurrentUser(data.user);
+      // Registration endpoint also returns the user fields directly
+      setCurrentUser(data);
       setIsAuthenticated(true);
       return data;
     } catch (err) {


### PR DESCRIPTION
## Summary
- store login API response directly in auth context
- store registration API response directly in auth context

## Testing
- `CI=true npm test` (fails: No tests found)

------
https://chatgpt.com/codex/tasks/task_e_6897a77ef6188332950b94fc613666fc