### PR TITLE
Allow CORS for Railway domains and fix manifest icons

### DIFF
--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -8,13 +8,13 @@
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
-      "type": "image/png",
+      "src": "logo192.svg",
+      "type": "image/svg+xml",
       "sizes": "192x192"
     },
     {
-      "src": "logo512.png",
-      "type": "image/png",
+      "src": "logo512.svg",
+      "type": "image/svg+xml",
       "sizes": "512x512"
     }
   ],

--- a/server/server.js
+++ b/server/server.js
@@ -21,14 +21,13 @@ const socketService = require('./services/socket.service');
 const app = express();
 
 // Middleware
-const allowedOrigins =
-  process.env.NODE_ENV === 'production'
-    ? [
-        process.env.CLIENT_URL,
-        'https://chatee.up.railway.app',
-        'https://livechat-production-d44b.up.railway.app',
-      ].filter(Boolean)
-    : ['http://localhost:3000'];
+// Allow requests from common deployment origins regardless of environment
+const allowedOrigins = [
+  'http://localhost:3000',
+  'https://chatee.up.railway.app',
+  'https://livechat-production-d44b.up.railway.app',
+  process.env.CLIENT_URL,
+].filter(Boolean);
 
 const corsOptions = {
   origin: (origin, callback) => {


### PR DESCRIPTION
## Summary
- Expand CORS whitelist to cover Railway deployment domains and localhost
- Use existing SVG icons in web app manifest to avoid missing file errors

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `CI=true npm test -- --watchAll=false` (client) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6897aaa634448332b4b49d4f90cf0329