### PR TITLE
Allow CORS for chatee domain and fix manifest icons

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -1,2 +1,3 @@
 # Production environment variables
-REACT_APP_API_URL=https://livechat-production-d44b.up.railway.app/api
+REACT_APP_API_URL=https://chatee.up.railway.app/api
+

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -8,13 +8,13 @@
       "type": "image/x-icon"
     },
     {
-      "src": "logo192.png",
-      "type": "image/png",
+      "src": "logo192.svg",
+      "type": "image/svg+xml",
       "sizes": "192x192"
     },
     {
-      "src": "logo512.png",
-      "type": "image/png",
+      "src": "logo512.svg",
+      "type": "image/svg+xml",
       "sizes": "512x512"
     }
   ],

--- a/server/.env.production
+++ b/server/.env.production
@@ -1,0 +1,3 @@
+# Production environment variables for the server
+CLIENT_URL=https://chatee.up.railway.app
+

--- a/server/server.js
+++ b/server/server.js
@@ -21,14 +21,11 @@ const socketService = require('./services/socket.service');
 const app = express();
 
 // Middleware
-const allowedOrigins =
-  process.env.NODE_ENV === 'production'
-    ? [
-        process.env.CLIENT_URL,
-        'https://chatee.up.railway.app',
-        'https://livechat-production-d44b.up.railway.app',
-      ].filter(Boolean)
-    : ['http://localhost:3000'];
+// Allow requests from common deployment origins regardless of environment
+const allowedOrigins = [
+  'http://localhost:3000',
+  process.env.CLIENT_URL,
+].filter(Boolean);
 
 const corsOptions = {
   origin: (origin, callback) => {


### PR DESCRIPTION
## Summary
- Rely on CLIENT_URL env var for CORS and remove old Railway domain
- Set server and client env vars to https://chatee.up.railway.app

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `CI=true npm test -- --watchAll=false` (client) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6897aaa634448332b4b49d4f90cf0329