### PR TITLE
Fix registration form email focus and server validation

### DIFF
--- a/client/src/components/bear/RegisterForm.js
+++ b/client/src/components/bear/RegisterForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
 import { useAuth } from '../../hooks/useAuth';
 import { useNavigate } from 'react-router-dom';
@@ -21,18 +21,12 @@ export function RegisterForm({
   setIsPasswordFocused,
   setIsConfirmPasswordFocused,
 }) {
-  const emailInputRef = useRef(null);
   const [errorMessage, setErrorMessage] = useState('');
   const { register } = useAuth();
   const navigate = useNavigate();
 
   const handleEmailFocus = () => {
     setIsEmailFocused(true);
-    setTimeout(() => {
-      if (emailInputRef.current) {
-        emailInputRef.current.selectionStart = emailInputRef.current.value.length;
-      }
-    }, 0);
   };
 
   const togglePasswordVisibility = (e) => {
@@ -62,8 +56,8 @@ const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       setErrorMessage('Passwords do not match');
       return;
     }
-    if (passwordValue.length < 6) {
-      setErrorMessage('Password must be at least 6 characters');
+    if (passwordValue.length < 8) {
+      setErrorMessage('Password must be at least 8 characters');
       return;
     }
     try {
@@ -109,7 +103,6 @@ const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         </label>
         <input
           id="email"
-          ref={emailInputRef}
           type="email"
           value={emailValue}
           onChange={(e) => setEmailValue(e.target.value)}

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -50,6 +50,10 @@ const register = async (req, res) => {
     }
   } catch (error) {
     console.error('Register error:', error);
+    if (error.name === 'ValidationError') {
+      const messages = Object.values(error.errors).map((err) => err.message);
+      return res.status(400).json({ message: messages.join(', ') });
+    }
     res.status(500).json({ message: 'Server error', error: error.message });
   }
 };


### PR DESCRIPTION
## Summary
- prevent email input from setting selectionStart to avoid invalid state error
- align password requirements with backend and improve server validation response

## Testing
- `npm test >/tmp/server-test.log; tail -n 20 /tmp/server-test.log`
- `cd client && CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6897b500df3c8332903c459a6a4b15a7