### PR TITLE
Fix login input focus error and credential handling

### DIFF
--- a/client/src/components/bear/LoginForm.js
+++ b/client/src/components/bear/LoginForm.js
@@ -21,9 +21,20 @@ export function LoginForm({
 
   const handleEmailFocus = () => {
     setIsEmailFocused(true);
+    // Some input types (like "email") don't allow direct manipulation of
+    // `selectionStart`.  Attempting to set it throws an InvalidStateError in
+    // certain browsers.  To avoid runtime errors we try to move the cursor
+    // inside a try/catch block and verify that the method exists before
+    // calling it.
     setTimeout(() => {
-      if (emailInputRef.current) {
-        emailInputRef.current.selectionStart = emailInputRef.current.value.length;
+      try {
+        const input = emailInputRef.current;
+        if (input && typeof input.setSelectionRange === 'function') {
+          const len = input.value.length;
+          input.setSelectionRange(len, len);
+        }
+      } catch (err) {
+        // Ignore unsupported input types
       }
     }, 0);
   };

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -66,9 +66,17 @@ const register = async (req, res) => {
 const login = async (req, res) => {
   try {
     const { email, password } = req.body;
+
+    // Ensure required fields are present before attempting to use them. When
+    // `email` is undefined, calling `trim()` throws an error which previously
+    // resulted in a 500 response.  Return a clear 400 message instead.
+    if (!email || !password) {
+      return res.status(400).json({ message: 'Email and password are required' });
+    }
+
     const normalizedEmail = email.trim().toLowerCase();
 
-   // Find user by email
+    // Find user by email
     const existingUser = await User.findOne({ email: normalizedEmail }).select('+password');
 
     // Check if user exists and password matches


### PR DESCRIPTION
## Summary
- prevent selectionStart error on email inputs when focusing login field
- validate login credentials on server and return 400 for missing fields

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `CI=true npm test --prefix client -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6897b7d5493083329695446593982fd8