### PR TITLE
Validate login inputs to prevent server errors

### DIFF
--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -67,10 +67,15 @@ const login = async (req, res) => {
   try {
     const { email, password } = req.body;
 
-    // Ensure required fields are present before attempting to use them. When
-    // `email` is undefined, calling `trim()` throws an error which previously
-    // resulted in a 500 response.  Return a clear 400 message instead.
-    if (!email || !password) {
+    // Ensure required fields are present and are strings before attempting to
+    // use them.  Calling `trim()` on a non-string or missing value would throw
+    // and result in a 500 response.  Return a clear 400 message instead.
+    if (
+      typeof email !== 'string' ||
+      typeof password !== 'string' ||
+      !email.trim() ||
+      !password.trim()
+    ) {
       return res.status(400).json({ message: 'Email and password are required' });
     }
 


### PR DESCRIPTION
## Summary
- Validate login credentials in the auth controller to avoid calling `trim` on undefined values and return a helpful 400 error instead of a 500 response

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68986cc5ee4483328887f69d296442c6