### PR TITLE
fix: ensure chat bubble text displays horizontally

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -106,6 +106,7 @@
   padding: 10px 14px;
   border-radius: 18px;
   line-height: 1.35;
+  writing-mode: horizontal-tb;
 }
 
 .msg-text {
@@ -113,6 +114,7 @@
   word-break: break-word;
   overflow-wrap: break-word;
   display: inline;
+  writing-mode: horizontal-tb;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- enforce horizontal layout in chat bubbles
- prevent vertical text rendering in message spans

## Testing
- `npm test` (fails: Missing script "test")
- `cd client && npm test -- --watchAll=false` (fails: No tests found, exit 1)
- `cd server && npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a82c9eac74833282db3604401ab221