### PR TITLE
feat: add delete message options

### DIFF
--- a/client/src/components/chat/MessageList.js
+++ b/client/src/components/chat/MessageList.js
@@ -1,19 +1,39 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useChat } from '../../hooks/useChat';
 import groupMessages from '../../utils/groupMessages';
 import DateDivider from './DateDivider';
 import MessageGroup from './MessageGroup';
+import DeleteMessageModal from '../modals/DeleteMessageModal';
 
 const MessageList = ({ messages, currentUser, selectedChat }) => {
   const { deleteMessageById } = useChat();
+  const [messageToDelete, setMessageToDelete] = useState(null);
 
   const groups = useMemo(() => groupMessages(messages), [messages]);
 
-  const handleDelete = async (id) => {
+  const handleDeleteRequest = (id) => {
+    setMessageToDelete(id);
+  };
+
+  const closeModal = () => {
+    setMessageToDelete(null);
+  };
+
+  const deleteForMe = async () => {
+    if (!messageToDelete) return;
     try {
-      await deleteMessageById(id, selectedChat._id, 'all');
+      await deleteMessageById(messageToDelete, selectedChat._id, 'me');
     } catch (err) {
-      console.error('Error deleting message:', err);
+      console.error('Error deleting message for me:', err);
+    }
+  };
+
+  const deleteForEveryone = async () => {
+    if (!messageToDelete) return;
+    try {
+      await deleteMessageById(messageToDelete, selectedChat._id, 'all');
+    } catch (err) {
+      console.error('Error deleting message for everyone:', err);
     }
   };
 
@@ -27,10 +47,22 @@ const MessageList = ({ messages, currentUser, selectedChat }) => {
         return (
           <React.Fragment key={group.key}>
             {showDivider && <DateDivider date={group.startAt} />}
-            <MessageGroup group={group} currentUser={currentUser} onDelete={handleDelete} />
+            <MessageGroup
+              group={group}
+              currentUser={currentUser}
+              onDelete={handleDeleteRequest}
+            />
           </React.Fragment>
         );
       })}
+      {messageToDelete && (
+        <DeleteMessageModal
+          isOpen={!!messageToDelete}
+          onClose={closeModal}
+          onDeleteForMe={deleteForMe}
+          onDeleteForEveryone={deleteForEveryone}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add modal to choose deleting a message for self or everyone
- update chat context to support per-user deletion and latest message updates

## Testing
- `CI=true npm test`
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68a834e21cb083328619cfe20ecd3ba5