### PR TITLE
Persist chat attachments across deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ The application comes with two test accounts:
 
 ## Recent Bug Fixes and Improvements
 
+### Persistent Attachment Storage
+
+**Issue:** Image attachments were stored on the server's local filesystem, causing them to break after redeploys or updates.
+
+**Fix:** Uploads are now converted to Base64 and saved with messages in the database, ensuring images remain visible in chat history even after server updates.
+
 ### MongoDB Connection and Server Configuration Fix (Latest)
 
 **Issue:** The backend server was hanging and not starting properly due to MongoDB connection issues, preventing the group creation functionality and WebSocket connections from working.

--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -236,10 +236,10 @@ const uploadAttachments = async (req, res) => {
     if (!req.files || req.files.length === 0) {
       return res.status(400).json({ message: 'No files uploaded' });
     }
-
+    // Convert files to Base64 data URLs so they persist in the database
     const attachments = req.files.map((file) => ({
       type: file.mimetype,
-      url: `${req.protocol}://${req.get('host')}/uploads/${file.filename}`,
+      url: `data:${file.mimetype};base64,${file.buffer.toString('base64')}`,
       name: file.originalname,
       size: file.size,
     }));

--- a/server/routes/message.routes.js
+++ b/server/routes/message.routes.js
@@ -9,18 +9,10 @@ const {
   uploadAttachments,
 } = require('../controllers/message.controller');
 const multer = require('multer');
-const path = require('path');
-const {
-  generateUniqueFilename,
-  isValidFileType,
-} = require('../utils/fileUpload');
+const { isValidFileType } = require('../utils/fileUpload');
 
-const storage = multer.diskStorage({
-  destination: path.join(__dirname, '../uploads'),
-  filename: (req, file, cb) => {
-    cb(null, generateUniqueFilename(file.originalname));
-  },
-});
+// Store files in memory so we can convert them to Base64 before saving
+const storage = multer.memoryStorage();
 
 const upload = multer({
   storage,

--- a/server/server.js
+++ b/server/server.js
@@ -50,7 +50,9 @@ const corsOptions = {
 
 app.use(cors(corsOptions));
 app.options('*', cors(corsOptions));
-app.use(express.json());
+// Increase body size limit so Base64-encoded attachments can be sent
+app.use(express.json({ limit: '10mb' }));
+app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 const path = require('path');
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 


### PR DESCRIPTION
## Summary
- Encode uploaded attachments as Base64 data URLs so they are stored with messages
- Use in-memory multer storage to avoid relying on local filesystem for uploads
- Increase JSON body size limit to allow sending Base64 attachments
- Document persistent attachment handling in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8672c265c8332803aafa10b8769f5