### PR TITLE
chore(domain): point prod to https://chatee.online (+ CORS allowlist)

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -1,3 +1,2 @@
-# Production environment variables
-REACT_APP_API_URL=https://chatee.up.railway.app/api
+REACT_APP_API_URL=https://chatee.online/api
 

--- a/server/.env.production
+++ b/server/.env.production
@@ -1,3 +1,2 @@
-# Production environment variables for the server
-CLIENT_URL=https://chatee.up.railway.app
+CLIENT_URL=https://chatee.online,https://www.chatee.online
 


### PR DESCRIPTION
## Summary
- update client prod API URL to chatee.online
- update server prod client URL to chatee.online and www variant
- use CLIENT_URL list in server CORS allowlist

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac4a43355083328f2d72e946cb3913