### PR TITLE
Fix avatar display with time divider

### DIFF
--- a/client/src/components/chat/MessageGroup.js
+++ b/client/src/components/chat/MessageGroup.js
@@ -44,7 +44,8 @@ const MessageGroup = ({ group, currentUser, onDelete, prevMessageDate }) => {
   const isOwn = (group.sender._id || group.sender.id) === (currentUser._id || currentUser.id);
   let last = prevMessageDate ? new Date(prevMessageDate) : null;
   const elements = [];
-  group.items.forEach((m, idx) => {
+  let prevType = 'divider';
+  group.items.forEach((m) => {
     const msgDate = new Date(m.createdAt);
     const minuteChanged =
       !last ||
@@ -54,12 +55,14 @@ const MessageGroup = ({ group, currentUser, onDelete, prevMessageDate }) => {
       elements.push(
         <TimeDivider key={`time-${m.id || m._id}`} time={msgDate} />
       );
+      prevType = 'divider';
     }
-    if (idx === 0) {
+    const showAvatar = prevType !== 'message';
+    if (showAvatar) {
       const shortTime = format(msgDate, 'h:mm a');
       const fullTime = msgDate.toLocaleString();
       elements.push(
-        <div key={m.id || m._id} className="grid grid-cols-[48px_1fr] gap-3">
+        <div key={m.id || m._id} className="message-row grid grid-cols-[48px_1fr] gap-3">
           <img
             src={avatarUrl(group.sender)}
             className="w-12 h-12 rounded-full"
@@ -78,13 +81,14 @@ const MessageGroup = ({ group, currentUser, onDelete, prevMessageDate }) => {
       elements.push(
         <div
           key={m.id || m._id}
-          className="grid grid-cols-[48px_1fr] gap-3 mt-1"
+          className="message-row grid grid-cols-[48px_1fr] gap-3 mt-1"
         >
-          <div />
+          <div className="avatar-spacer" />
           <MessageItem message={m} isOwn={isOwn} onDelete={onDelete} />
         </div>
       );
     }
+    prevType = 'message';
     last = msgDate;
   });
 

--- a/client/src/components/chat/TimeDivider.js
+++ b/client/src/components/chat/TimeDivider.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { format } from 'date-fns';
 
 const TimeDivider = ({ time }) => (
-  <div className="my-2 text-center">
-    <span className="text-xs text-gray-400">{format(new Date(time), 'h:mm a')}</span>
+  <div className="time-divider">
+    <span>{format(new Date(time), 'h:mm a')}</span>
   </div>
 );
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -171,6 +171,18 @@
   min-width: 0;
 }
 
+.avatar-spacer {
+  width: 48px;
+}
+
+.time-divider {
+  @apply my-2 text-center;
+}
+
+.time-divider span {
+  @apply text-xs text-gray-400;
+}
+
 
 /* Reactions and quotes placeholder classes */
 .reaction-row {


### PR DESCRIPTION
## Summary
- Ensure time dividers are treated as non-message items
- Only hide avatars when the previous item is a message from the same user
- Add CSS classes for `time-divider` and `avatar-spacer`

## Testing
- `cd client && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68ac555323fc833299a2245c028a2081