### PR TITLE
Add backend thread message support

### DIFF
--- a/server/models/message.model.js
+++ b/server/models/message.model.js
@@ -16,6 +16,15 @@ const messageSchema = new mongoose.Schema(
       ref: 'Chat',
       required: true
     },
+    parentMessage: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Message',
+      default: null
+    },
+    threadCount: {
+      type: Number,
+      default: 0
+    },
     readBy: [
       {
         type: mongoose.Schema.Types.ObjectId,

--- a/server/routes/message.routes.js
+++ b/server/routes/message.routes.js
@@ -7,6 +7,7 @@ const {
   deleteMessage,
   searchMessages,
   uploadAttachments,
+  getThread,
 } = require('../controllers/message.controller');
 const multer = require('multer');
 const { isValidFileType } = require('../utils/fileUpload');
@@ -35,6 +36,9 @@ router.post('/upload', upload.array('files'), uploadAttachments);
 
 // Send a new message
 router.post('/', sendMessage);
+
+// Get a message thread
+router.get('/:id/thread', getThread);
 
 // Get all messages for a chat
 router.get('/:chatId', getMessages);

--- a/server/services/socket.service.js
+++ b/server/services/socket.service.js
@@ -63,6 +63,19 @@ const socketService = (io) => {
       });
     });
 
+    // Handle new thread message
+    socket.on('new-thread-message', (messageData) => {
+      const chat = messageData.chat;
+
+      if (!chat.users) return console.log('Chat users not defined');
+
+      chat.users.forEach((user) => {
+        if (user._id !== messageData.sender._id) {
+          socket.to(user._id).emit('thread:messageCreated', messageData);
+        }
+      });
+    });
+
     // Handle typing status
     socket.on('typing', (chatId) => {
       socket.to(chatId).emit('typing', { chatId, userId: socket.userId });


### PR DESCRIPTION
## Summary
- store parentMessage and threadCount for messages
- expose thread retrieval and update thread count when replying
- broadcast thread messages through Socket.IO

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm test -- --watchAll=false` (client)


------
https://chatgpt.com/codex/tasks/task_e_68ac5c36a63483328a78d08e00d5fb45