### PR TITLE
feat: support replying to messages

### DIFF
--- a/client/src/components/chat/MessageGroup.js
+++ b/client/src/components/chat/MessageGroup.js
@@ -12,7 +12,15 @@ const avatarUrl = (sender) => {
   );
 };
 
-const MessageGroup = ({ group, currentUser, onDelete, prevMessageDate }) => {
+const MessageGroup = ({
+  group,
+  currentUser,
+  onDelete,
+  prevMessageDate,
+  registerMessageRef,
+  onReply,
+  scrollToMessage,
+}) => {
   if (!group.sender) {
     // system messages
     let last = prevMessageDate ? new Date(prevMessageDate) : null;
@@ -73,7 +81,14 @@ const MessageGroup = ({ group, currentUser, onDelete, prevMessageDate }) => {
               <span className="font-medium text-sm">{group.sender.name}</span>
               <time className="text-xs text-gray-500" title={fullTime}>{shortTime}</time>
             </div>
-            <MessageItem message={m} isOwn={isOwn} onDelete={onDelete} />
+            <MessageItem
+              ref={registerMessageRef(m._id || m.id)}
+              message={m}
+              isOwn={isOwn}
+              onDelete={onDelete}
+              onReply={() => onReply(m)}
+              scrollToMessage={scrollToMessage}
+            />
           </div>
         </div>
       );
@@ -84,7 +99,14 @@ const MessageGroup = ({ group, currentUser, onDelete, prevMessageDate }) => {
           className="message-row grid grid-cols-[48px_1fr] gap-3 mt-1"
         >
           <div className="avatar-spacer" />
-          <MessageItem message={m} isOwn={isOwn} onDelete={onDelete} />
+          <MessageItem
+            ref={registerMessageRef(m._id || m.id)}
+            message={m}
+            isOwn={isOwn}
+            onDelete={onDelete}
+            onReply={() => onReply(m)}
+            scrollToMessage={scrollToMessage}
+          />
         </div>
       );
     }

--- a/client/src/components/chat/MessageItem.js
+++ b/client/src/components/chat/MessageItem.js
@@ -1,103 +1,175 @@
 import React from 'react';
-import { ClipboardIcon, TrashIcon, ArrowUturnLeftIcon } from '@heroicons/react/24/outline';
+import {
+  ClipboardIcon,
+  TrashIcon,
+  ArrowUturnLeftIcon,
+  ArrowUturnRightIcon,
+} from '@heroicons/react/24/outline';
 import { useChat } from '../../hooks/useChat';
 import linkify from '../../utils/linkify';
 import ReactionBar from './ReactionBar';
 
-const MessageItem = ({ message, isOwn, onDelete }) => {
-  const { openThread, currentUser, toggleReaction } = useChat();
-  const barRef = React.useRef();
-  const isTouch = typeof window !== 'undefined' && 'ontouchstart' in window;
-  const text = message.text || message.content;
+const MessageItem = React.forwardRef(
+  ({ message, isOwn, onDelete, onReply, scrollToMessage }, ref) => {
+    const { openThread, currentUser, toggleReaction } = useChat();
+    const barRef = React.useRef();
+    const isTouch = typeof window !== 'undefined' && 'ontouchstart' in window;
+    const text = message.text || message.content;
+    const [swipeX, setSwipeX] = React.useState(0);
+    const touchStart = React.useRef(0);
 
-  const handleKeyDown = (e) => {
-    if (e.key === ':') {
-      e.preventDefault();
-      barRef.current?.openPicker();
-    }
-  };
+    const handleKeyDown = (e) => {
+      if (e.key === ':') {
+        e.preventDefault();
+        barRef.current?.openPicker();
+      }
+    };
 
-  const handleCopy = () => {
-    if (text) {
-      navigator.clipboard?.writeText(text);
-    }
-  };
+    const handleCopy = () => {
+      if (text) {
+        navigator.clipboard?.writeText(text);
+      }
+    };
 
-  const handleDelete = () => {
-    if (onDelete) {
-      onDelete(message._id || message.id);
-    }
-  };
+    const handleDelete = () => {
+      if (onDelete) {
+        onDelete(message._id || message.id);
+      }
+    };
 
-  const renderAttachment = (attachment) => {
-    const type = attachment.type || '';
-    if (type.startsWith('image/')) {
+    const handleTouchStart = (e) => {
+      touchStart.current = e.touches[0].clientX;
+    };
+
+    const handleTouchMove = (e) => {
+      const delta = e.touches[0].clientX - touchStart.current;
+      if (delta > 0) {
+        setSwipeX(Math.min(delta, 80));
+      }
+    };
+
+    const handleTouchEnd = () => {
+      if (swipeX > 48 && onReply) {
+        onReply();
+      }
+      setSwipeX(0);
+    };
+
+    const renderAttachment = (attachment) => {
+      const type = attachment.type || '';
+      if (type.startsWith('image/')) {
+        return (
+          <img
+            src={attachment.url}
+            alt={attachment.name || 'image'}
+            className="mt-2 max-w-xs rounded-md"
+          />
+        );
+      }
       return (
-        <img
-          src={attachment.url}
-          alt={attachment.name || 'image'}
-          className="mt-2 max-w-xs rounded-md" />
-      );
-    }
-    return (
-      <a
-        href={attachment.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="mt-2 inline-block text-sm text-blue-600 underline"
-      >
-        {attachment.name || 'Attachment'}
-      </a>
-    );
-  };
-
-  return (
-    <div className="relative group" tabIndex={0} onKeyDown={handleKeyDown}>
-      {text && (
-        <div className="text-[15px] leading-6 whitespace-pre-wrap break-words">
-          {linkify(text)}
-        </div>
-      )}
-      {message.attachments && message.attachments.map((att) => (
-        <div key={att.id || att.url}>{renderAttachment(att)}</div>
-      ))}
-      <div
-        className={`absolute -top-8 left-0 transition-opacity ${
-          isTouch ? '' : 'opacity-0 group-hover:opacity-100'
-        }`}
-      >
-        <ReactionBar
-          ref={barRef}
-          message={message}
-          currentUserId={currentUser?._id}
-          onReact={(emoji) => toggleReaction(message._id || message.id, emoji)}
-        />
-      </div>
-      <div className="absolute -top-2 right-0 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-        <button onClick={handleCopy} className="p-1 hover:bg-gray-200 rounded" title="Copy">
-          <ClipboardIcon className="h-4 w-4" />
-        </button>
-        {!message.parentMessageId && (
-          <button onClick={() => openThread(message)} className="p-1 hover:bg-gray-200 rounded" title="Reply in thread">
-            <ArrowUturnLeftIcon className="h-4 w-4" />
-          </button>
-        )}
-        {isOwn && (
-          <button onClick={handleDelete} className="p-1 hover:bg-gray-200 rounded" title="Delete">
-            <TrashIcon className="h-4 w-4" />
-          </button>
-        )}
-      </div>
-      {message.threadCount > 0 && !message.parentMessageId && (
-        <button
-          onClick={() => openThread(message)}
-          className="mt-1 text-xs text-blue-600 hover:underline"
+        <a
+          href={attachment.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-block text-sm text-blue-600 underline"
         >
-          {message.threadCount} {message.threadCount === 1 ? 'reply' : 'replies'} → View thread
-        </button>
-      )}
-    </div>
-  );
-};
+          {attachment.name || 'Attachment'}
+        </a>
+      );
+    };
+    return (
+      <div
+        ref={ref}
+        className="relative group"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        style={{ transform: `translateX(${swipeX}px)` }}
+      >
+        {message.replyToSnapshot && (
+          <div
+            onClick={() => scrollToMessage && scrollToMessage(message.replyToId)}
+            className="mb-1 p-2 rounded bg-gray-200 dark:bg-gray-600 text-sm cursor-pointer"
+          >
+            <div className="text-xs text-gray-500">
+              {message.replyToSnapshot.senderName}
+            </div>
+            <div className="truncate">{message.replyToSnapshot.text}</div>
+          </div>
+        )}
+        {text && (
+          <div className="text-[15px] leading-6 whitespace-pre-wrap break-words">
+            {linkify(text)}
+          </div>
+        )}
+        {message.attachments &&
+          message.attachments.map((att) => (
+            <div key={att.id || att.url}>{renderAttachment(att)}</div>
+          ))}
+        <div
+          className={`absolute -top-8 left-0 transition-opacity ${
+            isTouch ? '' : 'opacity-0 group-hover:opacity-100'
+          }`}
+        >
+          <ReactionBar
+            ref={barRef}
+            message={message}
+            currentUserId={currentUser?._id}
+            onReact={(emoji) =>
+              toggleReaction(message._id || message.id, emoji)
+            }
+          />
+        </div>
+        <div className="absolute -top-2 right-0 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button
+            onClick={handleCopy}
+            className="p-1 hover:bg-gray-200 rounded"
+            title="Copy"
+          >
+            <ClipboardIcon className="h-4 w-4" />
+          </button>
+          {onReply && (
+            <button
+              onClick={onReply}
+              className="p-1 hover:bg-gray-200 rounded"
+              title="Reply"
+            >
+              <ArrowUturnRightIcon className="h-4 w-4" />
+            </button>
+          )}
+          {!message.parentMessageId && (
+            <button
+              onClick={() => openThread(message)}
+              className="p-1 hover:bg-gray-200 rounded"
+              title="Reply in thread"
+            >
+              <ArrowUturnLeftIcon className="h-4 w-4" />
+            </button>
+          )}
+          {isOwn && (
+            <button
+              onClick={handleDelete}
+              className="p-1 hover:bg-gray-200 rounded"
+              title="Delete"
+            >
+              <TrashIcon className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+        {message.threadCount > 0 && !message.parentMessageId && (
+          <button
+            onClick={() => openThread(message)}
+            className="mt-1 text-xs text-blue-600 hover:underline"
+          >
+            {message.threadCount}{' '}
+            {message.threadCount === 1 ? 'reply' : 'replies'} → View thread
+          </button>
+        )}
+      </div>
+    );
+  }
+);
 
 export default MessageItem;

--- a/client/src/components/chat/MessageList.js
+++ b/client/src/components/chat/MessageList.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useRef } from 'react';
 import { useChat } from '../../hooks/useChat';
 import groupMessages from '../../utils/groupMessages';
 import DateDivider from './DateDivider';
@@ -7,8 +7,30 @@ import DeleteMessageModal from '../modals/DeleteMessageModal';
 import ThreadPanel from './ThreadPanel';
 
 const MessageList = ({ messages, currentUser, selectedChat }) => {
-  const { deleteMessageById } = useChat();
+  const { deleteMessageById, startReply } = useChat();
   const [messageToDelete, setMessageToDelete] = useState(null);
+  const messageRefs = useRef({});
+
+  const registerMessageRef = (id) => (el) => {
+    if (el) {
+      messageRefs.current[id] = el;
+    }
+  };
+
+  const scrollToMessage = (id) => {
+    const el = messageRefs.current[id];
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      el.classList.add('ring-2', 'ring-blue-400');
+      setTimeout(() => {
+        el.classList.remove('ring-2', 'ring-blue-400');
+      }, 2000);
+    }
+  };
+
+  const handleReply = (message) => {
+    startReply(message);
+  };
 
   const groups = useMemo(() => groupMessages(messages), [messages]);
 
@@ -54,6 +76,9 @@ const MessageList = ({ messages, currentUser, selectedChat }) => {
               currentUser={currentUser}
               onDelete={handleDeleteRequest}
               prevMessageDate={lastMessageDate}
+              registerMessageRef={registerMessageRef}
+              onReply={handleReply}
+              scrollToMessage={scrollToMessage}
             />
           </React.Fragment>
         );

--- a/client/src/services/messageService.js
+++ b/client/src/services/messageService.js
@@ -21,7 +21,13 @@ export const getMessages = async (chatId) => {
  * @param {Array} attachments - Optional array of attachment files
  * @returns {Promise<Object>} Created message
  */
-export const sendMessage = async (chatId, content, attachments = [], parentMessageId) => {
+export const sendMessage = async (
+  chatId,
+  content,
+  attachments = [],
+  parentMessageId,
+  reply
+) => {
   try {
     const payload = { chatId };
 
@@ -35,6 +41,14 @@ export const sendMessage = async (chatId, content, attachments = [], parentMessa
 
     if (parentMessageId) {
       payload.parentMessageId = parentMessageId;
+    }
+    if (reply) {
+      if (reply.id) {
+        payload.replyToId = reply.id;
+      }
+      if (reply.snapshot) {
+        payload.replyToSnapshot = reply.snapshot;
+      }
     }
 
     const response = await axios.post(`${API_URL}/messages`, payload);

--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -15,7 +15,14 @@ const {
  */
 const sendMessage = async (req, res) => {
   try {
-    const { content, chatId, attachments = [], parentMessageId } = req.body;
+    const {
+      content,
+      chatId,
+      attachments = [],
+      parentMessageId,
+      replyToId,
+      replyToSnapshot,
+    } = req.body;
 
     if (!content && (!attachments || attachments.length === 0)) {
       return res.status(400).json({ message: 'Message content or attachments are required' });
@@ -39,6 +46,12 @@ const sendMessage = async (req, res) => {
 
     if (parentMessageId) {
       newMessage.parentMessage = parentMessageId;
+    }
+    if (replyToId) {
+      newMessage.replyToId = replyToId;
+    }
+    if (replyToSnapshot) {
+      newMessage.replyToSnapshot = replyToSnapshot;
     }
 
     // Save the message

--- a/server/models/message.model.js
+++ b/server/models/message.model.js
@@ -21,6 +21,15 @@ const messageSchema = new mongoose.Schema(
       ref: 'Message',
       default: null
     },
+    replyToId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Message',
+      default: null
+    },
+    replyToSnapshot: {
+      senderName: { type: String },
+      text: { type: String }
+    },
     threadCount: {
       type: Number,
       default: 0


### PR DESCRIPTION
## Summary
- allow messages to include `replyToId` and snapshot data on server and client
- add reply banner, preview, swipe/hover actions and scroll-to-original behaviour
- expose reply helpers in chat context and message components

## Testing
- `npm test -- --watchAll=false` (client)
- `npm test` (server, fails: no test specified)
- `npm test` (missing script)


------
https://chatgpt.com/codex/tasks/task_e_68ad6d00f70c83329c69940c2d344d66