### PR TITLE
feat: add emoji reactions

### DIFF
--- a/client/src/components/chat/ReactionChips.js
+++ b/client/src/components/chat/ReactionChips.js
@@ -1,0 +1,34 @@
+import React, { useMemo } from 'react';
+
+const ReactionChips = ({ message, currentUserId, onReact }) => {
+  const reactions = useMemo(() => {
+    const map = new Map();
+    (message.reactions || []).forEach(({ emoji, userId }) => {
+      if (!map.has(emoji)) map.set(emoji, []);
+      map.get(emoji).push(userId);
+    });
+    return Array.from(map.entries()).map(([emoji, users]) => ({ emoji, users }));
+  }, [message.reactions]);
+
+  if (!reactions.length) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1 mt-1">
+      {reactions.map(({ emoji, users }) => {
+        const reacted = users.includes(currentUserId);
+        return (
+          <button
+            key={emoji}
+            onClick={() => onReact(emoji)}
+            className={`text-xs px-2 py-0.5 rounded-full border flex items-center max-w-[60px] truncate ${reacted ? 'bg-blue-100 border-blue-300' : 'bg-gray-100 border-gray-200'}`}
+          >
+            <span className="mr-1">{emoji}</span>
+            <span className="truncate">{users.length}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ReactionChips;

--- a/server/models/reaction.model.js
+++ b/server/models/reaction.model.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose');
+
+const reactionSchema = new mongoose.Schema(
+  {
+    message: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Message',
+      required: true,
+    },
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    emoji: {
+      type: String,
+      required: true,
+    },
+  },
+  { timestamps: true }
+);
+
+reactionSchema.index({ message: 1, user: 1, emoji: 1 }, { unique: true });
+
+module.exports = mongoose.model('Reaction', reactionSchema);

--- a/server/routes/message.routes.js
+++ b/server/routes/message.routes.js
@@ -8,6 +8,7 @@ const {
   searchMessages,
   uploadAttachments,
   getThread,
+  toggleReaction,
 } = require('../controllers/message.controller');
 const multer = require('multer');
 const { isValidFileType } = require('../utils/fileUpload');
@@ -39,6 +40,9 @@ router.post('/', sendMessage);
 
 // Get a message thread
 router.get('/:id/thread', getThread);
+
+// Toggle reaction
+router.post('/:id/reactions', toggleReaction);
 
 // Get all messages for a chat
 router.get('/:chatId', getMessages);

--- a/server/server.js
+++ b/server/server.js
@@ -92,6 +92,9 @@ const io = socketIo(server, {
   },
 });
 
+// Make io accessible in routes
+app.set('io', io);
+
 // Initialize socket service
 socketService(io);
 


### PR DESCRIPTION
## Summary
- add reaction model and socket-powered API to toggle emojis on messages
- replace old reaction picker with hover/long-press emoji bar and chips display
- wire reaction data through message queries and realtime updates

## Testing
- `npm test --prefix server` (fails: Error: no test specified)
- `npm test --prefix client -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68ad6dd477208332a64c44b0b1a561e5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Message reactions: add or remove emoji reactions on messages and threads with real-time updates.
  * Reaction chips display counts and your own reaction state; tap/click to toggle.
  * New reaction bar with accessible emoji buttons.

* Improvements
  * Easier interaction: press “r” to open reactions; Esc to close.
  * Hover delay on desktop, long-press on touch to reveal the reaction bar.
  * Reactions persist across views and are removed when a message is deleted.
  * More consistent positioning and behavior of the reaction overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->