### PR TITLE
feat: add unread divider and sticky jump button

### DIFF
--- a/client/src/components/chat/UnreadDivider.js
+++ b/client/src/components/chat/UnreadDivider.js
@@ -1,0 +1,13 @@
+import React, { forwardRef } from 'react';
+
+const UnreadDivider = forwardRef((props, ref) => (
+  <div ref={ref} className="my-4 flex items-center gap-3" {...props}>
+    <div className="h-px bg-gray-200 flex-1" />
+    <div className="text-xs px-3 py-1 rounded-full bg-blue-100 text-blue-600">
+      Unread messages
+    </div>
+    <div className="h-px bg-gray-200 flex-1" />
+  </div>
+));
+
+export default UnreadDivider;

--- a/client/src/hooks/useStickyScroll.js
+++ b/client/src/hooks/useStickyScroll.js
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react';
+
+const useStickyScroll = ({ firstUnreadId, scrollToMessage, onReachedLatest, delay = 2000 }) => {
+  const listRef = useRef(null);
+  const dividerRef = useRef(null);
+  const bottomRef = useRef(null);
+  const [showUnreadButton, setShowUnreadButton] = useState(Boolean(firstUnreadId));
+
+  useEffect(() => {
+    setShowUnreadButton(Boolean(firstUnreadId));
+  }, [firstUnreadId]);
+
+  // Observe unread divider visibility
+  useEffect(() => {
+    const container = listRef.current?.closest('.chat-scroll') || listRef.current;
+    if (!container || !dividerRef.current) return;
+
+    const observer = new IntersectionObserver(([entry]) => {
+      setShowUnreadButton(!entry.isIntersecting && Boolean(firstUnreadId));
+    }, { root: container });
+
+    observer.observe(dividerRef.current);
+    return () => observer.disconnect();
+  }, [firstUnreadId]);
+
+  // Observe bottom of list to mark as read
+  useEffect(() => {
+    const container = listRef.current?.closest('.chat-scroll') || listRef.current;
+    if (!container || !bottomRef.current) return;
+    let timer;
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        timer = setTimeout(() => {
+          if (onReachedLatest) onReachedLatest();
+        }, delay);
+      } else if (timer) {
+        clearTimeout(timer);
+      }
+    }, { root: container });
+    observer.observe(bottomRef.current);
+    return () => {
+      observer.disconnect();
+      if (timer) clearTimeout(timer);
+    };
+  }, [onReachedLatest, delay]);
+
+  const jumpToUnread = () => {
+    if (firstUnreadId) scrollToMessage(firstUnreadId);
+  };
+
+  return { listRef, dividerRef, bottomRef, showUnreadButton, jumpToUnread };
+};
+
+export default useStickyScroll;


### PR DESCRIPTION
## Summary
- show unread divider and floating button to jump to first unread message
- track per-chat last read timestamps in context
- add sticky scroll hook for unread navigation and read tracking

## Testing
- `cd client && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68ad9e61e68c8332ac9b4f29ab63489a