### PR TITLE
Fix chat scroll and unread navigation

### DIFF
--- a/client/src/components/chat/ChatWindow.js
+++ b/client/src/components/chat/ChatWindow.js
@@ -25,17 +25,36 @@ const ChatWindow = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal
   
   const [isTyping, setIsTyping] = useState(false);
   const messagesEndRef = useRef(null);
-  
-  // Scroll to bottom when messages change
+  const scrollContainerRef = useRef(null);
+  const [autoScroll, setAutoScroll] = useState(true);
+
+  // Track whether user is at the bottom of the chat
+  const handleScroll = () => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const atBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight <
+      100;
+    setAutoScroll(atBottom);
+  };
+
+  // Scroll to bottom when new messages arrive only if user is at bottom
   useEffect(() => {
-    scrollToBottom();
-  }, [messages]);
+    if (autoScroll) {
+      scrollToBottom();
+    }
+  }, [messages, autoScroll]);
   
   // Fetch messages when selected chat changes
   useEffect(() => {
     if (selectedChat) {
       fetchMessages(selectedChat._id);
     }
+  }, [selectedChat]);
+
+  useEffect(() => {
+    scrollToBottom();
+    setAutoScroll(true);
   }, [selectedChat]);
   
   // Handle typing indicator
@@ -227,7 +246,11 @@ const ChatWindow = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal
           </div>
           
           {/* Messages */}
-          <div className="chat-scroll">
+          <div
+            ref={scrollContainerRef}
+            className="chat-scroll"
+            onScroll={handleScroll}
+          >
             <div className="chat-column">
               {messageLoading ? (
                 <div className="flex justify-center items-center h-full">

--- a/client/src/components/chat/MessageList.js
+++ b/client/src/components/chat/MessageList.js
@@ -160,9 +160,23 @@ const MessageList = ({ messages, currentUser, selectedChat }) => {
       {showUnreadButton && (
         <button
           onClick={jumpToUnread}
-          className="fixed right-4 bottom-24 md:bottom-6 px-4 py-2 rounded-full bg-primary-600 text-white shadow-lg"
+          aria-label="Jump to last unread"
+          className="fixed right-4 bottom-24 md:bottom-6 p-3 rounded-full bg-primary-600 text-white shadow-lg"
         >
-          Jump to last unread
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
         </button>
       )}
     </div>


### PR DESCRIPTION
## Summary
- allow manual scrolling without auto-jumping to newest messages
- add arrow button for jumping to first unread message

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ada8a59e388332af0f647a9f70c012