### PR TITLE
fix: enable chat history scrolling

### DIFF
--- a/client/src/components/chat/ChatWindow.js
+++ b/client/src/components/chat/ChatWindow.js
@@ -3,6 +3,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { useChat } from '../../hooks/useChat';
 import { useSocket } from '../../hooks/useSocket';
 import { useDebounce } from '../../hooks/useDebounce';
+import { isAtBottom } from '../../utils/scroll';
 
 // Components
 import MessageList from './MessageList';
@@ -28,14 +29,11 @@ const ChatWindow = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal
   const scrollContainerRef = useRef(null);
   const [autoScroll, setAutoScroll] = useState(true);
 
-  // Track whether user is at the bottom of the chat
+  // Track whether the user is near the bottom of the chat
   const handleScroll = () => {
     const container = scrollContainerRef.current;
     if (!container) return;
-    const atBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight <
-      100;
-    setAutoScroll(atBottom);
+    setAutoScroll(isAtBottom(container, 100));
   };
   
   // Fetch messages when selected chat changes
@@ -49,6 +47,14 @@ const ChatWindow = ({ toggleMobileMenu, openUserProfileModal, openGroupInfoModal
     scrollToBottom();
     setAutoScroll(true);
   }, [selectedChat]);
+
+  // Auto-scroll only when the user is already at the bottom
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (autoScroll && container && isAtBottom(container, 100)) {
+      scrollToBottom();
+    }
+  }, [messages, autoScroll]);
   
   // Handle typing indicator
   const debouncedIsTyping = useDebounce(isTyping, 1000);

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -82,12 +82,13 @@
 
 /* Chat layout */
 .chat-shell {
-  @apply flex flex-col h-full flex-1 transition-all duration-300;
+  @apply flex flex-col h-full flex-1 min-h-0 transition-all duration-300;
   background: var(--bg);
 }
 
 .chat-scroll {
-  @apply flex-1 overflow-y-auto overflow-x-hidden;
+  @apply flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 .chat-column {

--- a/client/src/pages/Chat.js
+++ b/client/src/pages/Chat.js
@@ -67,7 +67,7 @@ const Chat = () => {
   };
 
   return (
-    <div className="h-full flex relative">
+    <div className="h-full flex relative overscroll-none min-h-0">
       {isMobileMenuOpen && (
         <div
           className="fixed inset-0 bg-black/40 z-20 md:hidden transition-opacity"

--- a/client/src/utils/scroll.js
+++ b/client/src/utils/scroll.js
@@ -1,0 +1,4 @@
+export const isAtBottom = (el, thresholdPx = 4) => {
+  if (!el) return false;
+  return el.scrollHeight - el.scrollTop - el.clientHeight <= thresholdPx;
+};


### PR DESCRIPTION
## Summary
- ensure chat layout allows vertical overflow with `min-h-0` and mobile-friendly scroll behaviour
- gate auto-scroll with new `isAtBottom` helper so new messages only snap to bottom when user is already there
- prevent parent overscroll from stealing chat scroll

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68aea54972a48332a698b5d914c99fa8