### PR TITLE
Refactor chat scrolling with centralized ScrollManager

### DIFF
--- a/client/src/components/chat/MessageList.js
+++ b/client/src/components/chat/MessageList.js
@@ -8,7 +8,7 @@ import ThreadPanel from './ThreadPanel';
 import UnreadDivider from './UnreadDivider';
 import useStickyScroll from '../../hooks/useStickyScroll';
 
-const MessageList = ({ messages, currentUser, selectedChat }) => {
+const MessageList = ({ messages, currentUser, selectedChat, scrollManagerRef }) => {
   const { deleteMessageById, startReply, markMessageAsRead } = useChat();
   const [messageToDelete, setMessageToDelete] = useState(null);
   const messageRefs = useRef({});
@@ -38,7 +38,6 @@ const MessageList = ({ messages, currentUser, selectedChat }) => {
     dividerRef,
     bottomRef,
     showUnreadButton,
-    jumpToUnread,
   } = useStickyScroll({
     firstUnreadId,
     scrollToMessage,
@@ -160,7 +159,7 @@ const MessageList = ({ messages, currentUser, selectedChat }) => {
       {showUnreadButton && (
         // user must click to jump; no automatic scrolling
         <button
-          onClick={jumpToUnread}
+          onClick={() => scrollManagerRef.current.scrollToBottom('smooth')}
           aria-label="Jump to last unread"
           className="fixed right-4 bottom-24 md:bottom-6 p-3 rounded-full bg-primary-600 text-white shadow-lg"
         >

--- a/client/src/components/chat/ThreadPanel.js
+++ b/client/src/components/chat/ThreadPanel.js
@@ -9,7 +9,6 @@ const ThreadPanel = () => {
   const { currentUser } = useAuth();
   const [text, setText] = useState('');
   const panelRef = useRef(null);
-  const bottomRef = useRef(null);
 
   useEffect(() => {
     if (activeThreadParent) {
@@ -38,14 +37,7 @@ const ThreadPanel = () => {
     };
   }, [activeThreadParent, closeThread]);
 
-  useEffect(() => {
-    const last = threadMessages[threadMessages.length - 1];
-    if (!last) return;
-    const isMine = (last.sender?._id || last.sender?.id) === currentUser._id;
-    if (isMine) {
-      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [threadMessages, currentUser]);
+  // No automatic scrolling; user controls position
 
   if (!activeThreadParent) return null;
 
@@ -72,7 +64,6 @@ const ThreadPanel = () => {
               isOwn={(m.sender?._id || m.sender?.id) === currentUser._id}
             />
           ))}
-          <div ref={bottomRef} />
         </div>
         <form onSubmit={handleSubmit} className="p-2 border-t">
           <input

--- a/client/src/debug/hookScrollMethods.js
+++ b/client/src/debug/hookScrollMethods.js
@@ -1,0 +1,14 @@
+export function hookScrollMethods(el, tag = 'chat') {
+  const origScrollTo = el.scrollTo.bind(el);
+  el.scrollTo = (...args) => {
+    console.warn(`[SCROLL-TRACE:${tag}] scrollTo`, args, new Error().stack);
+    return origScrollTo(...args);
+  };
+  const origSIV = el.scrollIntoView && el.scrollIntoView.bind(el);
+  if (origSIV) {
+    el.scrollIntoView = (...args) => {
+      console.warn(`[SCROLL-TRACE:${tag}] scrollIntoView`, args, new Error().stack);
+      return origSIV(...args);
+    };
+  }
+}

--- a/client/src/scroll/ScrollManager.js
+++ b/client/src/scroll/ScrollManager.js
@@ -1,0 +1,47 @@
+export class ScrollManager {
+  constructor() {
+    this.container = null;
+    this.policy = { isUserAtBottom: true, initialLoaded: false };
+    this.bottomThreshold = 48;
+    this.onScroll = this.onScroll.bind(this);
+  }
+
+  attach(container) {
+    this.container = container;
+    container.addEventListener('scroll', this.onScroll, { passive: true });
+    this.recalcBottom();
+  }
+
+  detach() {
+    if (this.container) {
+      this.container.removeEventListener('scroll', this.onScroll);
+      this.container = null;
+    }
+  }
+
+  onScroll() {
+    this.recalcBottom();
+  }
+
+  recalcBottom() {
+    const el = this.container;
+    if (!el) return;
+    const dist = el.scrollHeight - el.scrollTop - el.clientHeight;
+    this.policy.isUserAtBottom = dist <= this.bottomThreshold;
+  }
+
+  scrollToBottom(behavior = 'auto') {
+    const el = this.container;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior });
+    this.policy.isUserAtBottom = true;
+  }
+
+  shouldFollowNewMessage({ isOwn }) {
+    if (isOwn) return true;
+    if (!this.policy.initialLoaded) return true;
+    return this.policy.isUserAtBottom;
+  }
+}
+
+export default ScrollManager;

--- a/client/src/utils/scroll.js
+++ b/client/src/utils/scroll.js
@@ -1,4 +1,0 @@
-export const isAtBottom = (el, thresholdPx = 4) => {
-  if (!el) return false;
-  return el.scrollHeight - el.scrollTop - el.clientHeight <= thresholdPx;
-};


### PR DESCRIPTION
## Summary
- add `ScrollManager` as the single source of truth for chat scrolling
- integrate `ScrollManager` into `ChatWindow` and route unread jumps through it
- remove miscellaneous auto-scroll hooks and add dev scroll tracing utility

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aee2c618788332b086940e3c5a414d