### PR TITLE
feat: add message delivery and read tracking

### DIFF
--- a/server/models/conversationParticipant.model.js
+++ b/server/models/conversationParticipant.model.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const conversationParticipantSchema = new mongoose.Schema(
+  {
+    chat: { type: mongoose.Schema.Types.ObjectId, ref: 'Chat', required: true },
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    lastReadMessage: { type: mongoose.Schema.Types.ObjectId, ref: 'Message', default: null },
+    lastReadAt: { type: Date, default: null }
+  },
+  { timestamps: true }
+);
+
+conversationParticipantSchema.index({ chat: 1, user: 1 }, { unique: true });
+
+module.exports = mongoose.model('ConversationParticipant', conversationParticipantSchema);

--- a/server/models/message.model.js
+++ b/server/models/message.model.js
@@ -34,10 +34,21 @@ const messageSchema = new mongoose.Schema(
       type: Number,
       default: 0
     },
+    status: {
+      type: String,
+      enum: ['sent', 'delivered_all', 'read_all'],
+      default: 'sent'
+    },
+    deliveredTo: [
+      {
+        user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+        at: { type: Date, default: Date.now }
+      }
+    ],
     readBy: [
       {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'User'
+        user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+        at: { type: Date, default: Date.now }
       }
     ],
     attachments: [
@@ -74,6 +85,10 @@ const messageSchema = new mongoose.Schema(
     timestamps: true
   }
 );
+
+messageSchema.index({ chat: 1, createdAt: 1 });
+messageSchema.index({ 'deliveredTo.user': 1 });
+messageSchema.index({ 'readBy.user': 1 });
 
 const Message = mongoose.model('Message', messageSchema);
 

--- a/server/routes/chat.routes.js
+++ b/server/routes/chat.routes.js
@@ -9,6 +9,7 @@ const {
   removeFromGroup,
   leaveGroup,
 } = require('../controllers/chat.controller');
+const { ackReadUpTo, getLastRead } = require('../controllers/message.controller');
 const { protect } = require('../middleware/auth.middleware');
 
 // All routes are protected
@@ -19,6 +20,12 @@ router.post('/', accessChat);
 
 // Get all chats for a user
 router.get('/', getChats);
+
+// Bulk read up to
+router.post('/:id/ack-read-up-to', ackReadUpTo);
+
+// Get last read positions
+router.get('/:id/last-read', getLastRead);
 
 // Create a group chat
 router.post('/group', createGroupChat);

--- a/server/routes/message.routes.js
+++ b/server/routes/message.routes.js
@@ -4,6 +4,8 @@ const {
   sendMessage,
   getMessages,
   markAsRead,
+  ackDelivery,
+  ackRead,
   deleteMessage,
   searchMessages,
   uploadAttachments,
@@ -37,6 +39,12 @@ router.post('/upload', upload.array('files'), uploadAttachments);
 
 // Send a new message
 router.post('/', sendMessage);
+
+// Acknowledge delivery
+router.post('/:id/ack-delivery', ackDelivery);
+
+// Acknowledge read for a single message
+router.post('/:id/ack-read', ackRead);
 
 // Get a message thread
 router.get('/:id/thread', getThread);


### PR DESCRIPTION
## Summary
- track per-message delivery and read states with delivered and read arrays
- emit and handle socket events for delivery and read acknowledgements
- show message status ticks and auto-acknowledge when messages enter view

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b052b1edbc8332ac8ef50aa2f3a444