### PR TITLE
Refactor message actions into accessible kebab menu

### DIFF
--- a/client/src/components/chat/MessageActionsMenu.js
+++ b/client/src/components/chat/MessageActionsMenu.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import { EllipsisVerticalIcon, ClipboardIcon, ArrowUturnLeftIcon, TrashIcon } from '@heroicons/react/24/outline';
+
+const MessageActionsMenu = ({
+  isOpen,
+  onOpen,
+  onClose,
+  onCopy,
+  onStartThread,
+  onDelete,
+  showStartThread,
+  showDelete,
+  isTouch,
+}) => {
+  const menuRef = React.useRef(null);
+  const buttonRef = React.useRef(null);
+
+  const toggleMenu = () => {
+    if (isOpen) onClose();
+    else onOpen();
+  };
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (e) => {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(e.target)
+      ) {
+        onClose();
+      }
+    };
+
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Tab') {
+        e.preventDefault();
+        const items = menuRef.current.querySelectorAll('button');
+        const currentIndex = Array.from(items).indexOf(document.activeElement);
+        let nextIndex = 0;
+        if (e.key === 'ArrowDown' || (!e.shiftKey && e.key === 'Tab')) {
+          nextIndex = (currentIndex + 1) % items.length;
+        } else if (e.key === 'ArrowUp' || (e.shiftKey && e.key === 'Tab')) {
+          nextIndex = (currentIndex - 1 + items.length) % items.length;
+        }
+        items[nextIndex]?.focus();
+      } else if (e.key === 'Enter') {
+        if (document.activeElement && document.activeElement.click) {
+          document.activeElement.click();
+        }
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    const first = menuRef.current.querySelector('button');
+    first && first.focus();
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  const handleAction = (action) => () => {
+    action();
+    onClose();
+  };
+
+  const menuButtonClass = isTouch ? '' : 'opacity-0 group-hover:opacity-100';
+
+  return (
+    <div className={`relative ${menuButtonClass} transition-opacity`}>
+      <button
+        ref={buttonRef}
+        aria-label="More options"
+        className="p-1 hover:bg-gray-200 rounded"
+        onClick={toggleMenu}
+      >
+        <EllipsisVerticalIcon className="h-4 w-4" />
+      </button>
+      {isOpen && (
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label="Message actions"
+          className={
+            "absolute z-30 right-0 mt-1 w-32 rounded-md shadow-lg bg-white dark:bg-gray-800 " +
+            "text-gray-700 dark:text-gray-200 py-1"
+          }
+        >
+          <button
+            role="menuitem"
+            onClick={handleAction(onCopy)}
+            className="flex w-full items-center gap-2 px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-600"
+          >
+            <ClipboardIcon className="h-4 w-4" /> Copy
+          </button>
+          {showStartThread && (
+            <button
+              role="menuitem"
+              onClick={handleAction(onStartThread)}
+              className="flex w-full items-center gap-2 px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-600"
+            >
+              <ArrowUturnLeftIcon className="h-4 w-4" /> Start Thread
+            </button>
+          )}
+          {showDelete && (
+            <button
+              role="menuitem"
+              onClick={handleAction(onDelete)}
+              className="flex w-full items-center gap-2 px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-600"
+            >
+              <TrashIcon className="h-4 w-4" /> Delete
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MessageActionsMenu;
+

--- a/client/src/components/chat/MessageActionsMenu.test.js
+++ b/client/src/components/chat/MessageActionsMenu.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MessageActionsMenu from './MessageActionsMenu';
+
+describe('MessageActionsMenu', () => {
+  function Wrapper() {
+    const [open, setOpen] = React.useState(false);
+    return (
+      <MessageActionsMenu
+        isOpen={open}
+        onOpen={() => setOpen(true)}
+        onClose={() => setOpen(false)}
+        onCopy={() => {}}
+        onStartThread={() => {}}
+        onDelete={() => {}}
+        showStartThread
+        showDelete
+        isTouch={false}
+      />
+    );
+  }
+
+  test('opens and closes on outside click', () => {
+    render(<Wrapper />);
+    const button = screen.getByLabelText(/more options/i);
+    fireEvent.click(button);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  test('closes on escape key', () => {
+    render(<Wrapper />);
+    const button = screen.getByLabelText(/more options/i);
+    fireEvent.click(button);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});
+

--- a/client/src/components/chat/MessageItem.js
+++ b/client/src/components/chat/MessageItem.js
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  ClipboardIcon,
-  TrashIcon,
-  ArrowUturnLeftIcon,
-  ArrowUturnRightIcon,
-  CheckIcon,
-} from '@heroicons/react/24/outline';
+import { ArrowUturnRightIcon, CheckIcon } from '@heroicons/react/24/outline';
 import { CheckIcon as CheckIconSolid } from '@heroicons/react/24/solid';
 import { SocketContext } from '../../contexts/SocketContext';
 import { useChat } from '../../hooks/useChat';
@@ -13,6 +7,7 @@ import linkify, { extractUrls } from '../../utils/linkify';
 import LinkPreviewCard from './LinkPreviewCard';
 import ReactionBar from './ReactionBar';
 import ReactionChips from './ReactionChips';
+import MessageActionsMenu from './MessageActionsMenu';
 
 const previewCache = {};
 
@@ -54,6 +49,7 @@ const MessageItem = React.forwardRef(({ message, isOwn, onDelete, onReply }, ref
   const isTouch = typeof window !== 'undefined' && 'ontouchstart' in window;
   const text = message.text || message.content;
   const [showBar, setShowBar] = React.useState(false);
+  const [showMenu, setShowMenu] = React.useState(false);
   const hoverTimeout = React.useRef();
   const pressTimeout = React.useRef();
   const urls = React.useMemo(() => extractUrls(text), [text]);
@@ -110,7 +106,7 @@ const MessageItem = React.forwardRef(({ message, isOwn, onDelete, onReply }, ref
 
   const handlePointerDown = () => {
     if (isTouch) {
-      pressTimeout.current = setTimeout(openBar, 350);
+      pressTimeout.current = setTimeout(() => setShowMenu(true), 350);
     }
   };
 
@@ -222,14 +218,7 @@ const MessageItem = React.forwardRef(({ message, isOwn, onDelete, onReply }, ref
         />
       )}
 
-      <div className="absolute -top-2 right-0 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-        <button
-          onClick={handleCopy}
-          className="p-1 hover:bg-gray-200 rounded"
-          title="Copy"
-        >
-          <ClipboardIcon className="h-4 w-4" />
-        </button>
+      <div className="absolute -top-2 right-0 flex gap-1">
         {onReply && (
           <button
             onClick={onReply}
@@ -239,24 +228,17 @@ const MessageItem = React.forwardRef(({ message, isOwn, onDelete, onReply }, ref
             <ArrowUturnRightIcon className="h-4 w-4" />
           </button>
         )}
-        {!message.parentMessageId && (
-          <button
-            onClick={() => openThread(message)}
-            className="p-1 hover:bg-gray-200 rounded"
-            title="Reply in thread"
-          >
-            <ArrowUturnLeftIcon className="h-4 w-4" />
-          </button>
-        )}
-        {isOwn && (
-          <button
-            onClick={handleDelete}
-            className="p-1 hover:bg-gray-200 rounded"
-            title="Delete"
-          >
-            <TrashIcon className="h-4 w-4" />
-          </button>
-        )}
+        <MessageActionsMenu
+          isOpen={showMenu}
+          onOpen={() => setShowMenu(true)}
+          onClose={() => setShowMenu(false)}
+          onCopy={handleCopy}
+          onStartThread={() => openThread(message)}
+          onDelete={handleDelete}
+          showStartThread={!message.parentMessageId}
+          showDelete={isOwn}
+          isTouch={isTouch}
+        />
       </div>
 
       {message.threadCount > 0 && !message.parentMessageId && (


### PR DESCRIPTION
## Summary
- refactor message actions so reply is always visible and remaining actions live in a kebab menu
- add accessible keyboard-trappable menu for copy, start thread and delete
- add tests for menu open/close behavior

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68b14a2ec2c0833290858780bc057460