### PR TITLE
Fix MessageItem missing import

### DIFF
--- a/client/src/components/chat/MessageItem.js
+++ b/client/src/components/chat/MessageItem.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { ArrowUturnRightIcon, CheckIcon } from '@heroicons/react/24/outline';
-import { CheckIcon as CheckIconSolid } from '@heroicons/react/24/solid';
+import { ArrowUturnRightIcon } from '@heroicons/react/24/outline';
 import { SocketContext } from '../../contexts/SocketContext';
 import { useChat } from '../../hooks/useChat';
 import linkify, { extractUrls } from '../../utils/linkify';
@@ -8,6 +7,7 @@ import LinkPreviewCard from './LinkPreviewCard';
 import ReactionBar from './ReactionBar';
 import ReactionChips from './ReactionChips';
 import MessageActionsMenu from './MessageActionsMenu';
+import MessageStatusTicks from './MessageStatusTicks';
 
 const previewCache = {};
 


### PR DESCRIPTION
## Summary
- Import `MessageStatusTicks` in `MessageItem` and remove unused icons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b15519a29083329b0444d7d529d2e1