### PR TITLE
feat: implement reverse infinite scroll for chat messages

### DIFF
--- a/client/src/services/messageService.js
+++ b/client/src/services/messageService.js
@@ -5,9 +5,11 @@ import api from 'services/apiClient';
  * @param {string} chatId - Chat ID
  * @returns {Promise<Array>} List of messages
  */
-export const getMessages = async (chatId) => {
+export const getMessages = async (chatId, { limit = 20, before } = {}, config = {}) => {
   try {
-    const response = await api.get(`/messages/${chatId}`);
+    const params = { chatId, limit };
+    if (before) params.before = before;
+    const response = await api.get('/messages', { params, ...config });
     return response.data;
   } catch (error) {
     throw error.response?.data || { message: 'Failed to fetch messages' };

--- a/client/src/utils/messagePagination.js
+++ b/client/src/utils/messagePagination.js
@@ -1,0 +1,17 @@
+export const mergeMessages = (existing, incoming) => {
+  const idSet = new Set(existing.map(m => m._id));
+  const filtered = incoming.filter(m => !idSet.has(m._id));
+  return [...filtered, ...existing];
+};
+
+export const retainScrollPosition = (el, prevHeight) => {
+  if (!el) return;
+  const diff = el.scrollHeight - prevHeight;
+  if (diff > 0) {
+    el.scrollTop += diff;
+  }
+};
+
+export const shouldLoadMore = ({ hasMore, loading }) => hasMore && !loading;
+
+export default { mergeMessages, retainScrollPosition, shouldLoadMore };

--- a/client/src/utils/messagePagination.test.js
+++ b/client/src/utils/messagePagination.test.js
@@ -1,0 +1,45 @@
+import { mergeMessages, retainScrollPosition, shouldLoadMore } from './messagePagination';
+
+describe('message pagination utils', () => {
+  const genMsgs = (count, start = 0) => {
+    const arr = [];
+    for (let i = 0; i < count; i++) {
+      arr.push({ _id: `${start + i}`, createdAt: new Date().toISOString() });
+    }
+    return arr;
+  };
+
+  test('initial load returns 20 items', () => {
+    const initial = genMsgs(20);
+    const merged = mergeMessages([], initial);
+    expect(merged).toHaveLength(20);
+  });
+
+  test('top-scroll load prepends 20 older items', () => {
+    const initial = genMsgs(20, 20);
+    let merged = mergeMessages([], initial);
+    merged = mergeMessages(merged, genMsgs(20, 0));
+    expect(merged).toHaveLength(40);
+    expect(merged[0]._id).toBe('0');
+  });
+
+  test('deduping avoids duplicates', () => {
+    const existing = genMsgs(20, 10);
+    const older = genMsgs(20, 0); // includes overlap 10-19
+    const merged = mergeMessages(existing, older);
+    expect(merged).toHaveLength(30);
+  });
+
+  test('retainScrollPosition keeps anchor', () => {
+    const el = { scrollHeight: 1000, scrollTop: 100 };
+    const prev = el.scrollHeight;
+    el.scrollHeight = 1200; // after prepending 200px
+    retainScrollPosition(el, prev);
+    expect(el.scrollTop).toBe(300);
+  });
+
+  test('shouldLoadMore respects hasMore flag', () => {
+    expect(shouldLoadMore({ hasMore: true, loading: false })).toBe(true);
+    expect(shouldLoadMore({ hasMore: false, loading: false })).toBe(false);
+  });
+});

--- a/server/models/message.model.js
+++ b/server/models/message.model.js
@@ -87,6 +87,7 @@ const messageSchema = new mongoose.Schema(
 );
 
 messageSchema.index({ chat: 1, createdAt: 1 });
+messageSchema.index({ chat: 1, createdAt: -1, _id: -1 });
 messageSchema.index({ 'deliveredTo.user': 1 });
 messageSchema.index({ 'readBy.user': 1 });
 

--- a/server/routes/message.routes.js
+++ b/server/routes/message.routes.js
@@ -52,8 +52,8 @@ router.get('/:id/thread', getThread);
 // Toggle reaction
 router.post('/:id/reactions', toggleReaction);
 
-// Get all messages for a chat
-router.get('/:chatId', getMessages);
+// Get messages for a chat with cursor-based pagination
+router.get('/', getMessages);
 
 // Mark messages as read
 router.put('/read/:chatId', markAsRead);


### PR DESCRIPTION
## Summary
- paginate message retrieval with cursor-based API and Mongo indexes
- add client-side reverse infinite scroll with anchor retention and new message toast
- include pagination utilities and tests

## Testing
- `CI=true npm test --silent` in `client`
- `npm test` in `server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b160b1f9808332a36d1e53e73a926b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Infinite scroll: older messages auto-load when you scroll near the top.
  - “New messages — Jump to latest” button appears when new messages arrive and you’re not at the bottom.
- Improvements
  - Scroll position is preserved when older messages load.
  - Loading indicator shows while older messages are fetched.
- Bug Fixes
  - Prevented duplicate messages in chats.
  - More reliable unread and latest message updates in chat lists.
- Performance
  - Faster, more efficient message loading with cursor-based pagination and optimized indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->