### PR TITLE
feat: improve reply workflow and menu

### DIFF
--- a/client/src/components/chat/MessageActionsMenu.js
+++ b/client/src/components/chat/MessageActionsMenu.js
@@ -1,10 +1,17 @@
 import React from 'react';
-import { EllipsisVerticalIcon, ClipboardIcon, ArrowUturnLeftIcon, TrashIcon } from '@heroicons/react/24/outline';
+import {
+  EllipsisVerticalIcon,
+  ClipboardIcon,
+  ArrowUturnLeftIcon,
+  ArrowUturnRightIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
 
 const MessageActionsMenu = ({
   isOpen,
   onOpen,
   onClose,
+  onReply,
   onCopy,
   onStartThread,
   onDelete,
@@ -96,6 +103,13 @@ const MessageActionsMenu = ({
             "text-gray-700 dark:text-gray-200 py-1"
           }
         >
+          <button
+            role="menuitem"
+            onClick={handleAction(onReply)}
+            className="flex w-full items-center gap-2 px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-600"
+          >
+            <ArrowUturnRightIcon className="h-4 w-4" /> Reply
+          </button>
           <button
             role="menuitem"
             onClick={handleAction(onCopy)}

--- a/client/src/components/chat/MessageActionsMenu.test.js
+++ b/client/src/components/chat/MessageActionsMenu.test.js
@@ -4,13 +4,14 @@ import '@testing-library/jest-dom';
 import MessageActionsMenu from './MessageActionsMenu';
 
 describe('MessageActionsMenu', () => {
-  function Wrapper() {
+  function Wrapper({ onReply = () => {} }) {
     const [open, setOpen] = React.useState(false);
     return (
       <MessageActionsMenu
         isOpen={open}
         onOpen={() => setOpen(true)}
         onClose={() => setOpen(false)}
+        onReply={onReply}
         onCopy={() => {}}
         onStartThread={() => {}}
         onDelete={() => {}}
@@ -36,6 +37,17 @@ describe('MessageActionsMenu', () => {
     fireEvent.click(button);
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  test('reply is first option and triggers callback', () => {
+    const handleReply = jest.fn();
+    render(<Wrapper onReply={handleReply} />);
+    const button = screen.getByLabelText(/more options/i);
+    fireEvent.click(button);
+    const items = screen.getAllByRole('menuitem');
+    expect(items[0]).toHaveTextContent(/reply/i);
+    fireEvent.click(items[0]);
+    expect(handleReply).toHaveBeenCalled();
   });
 });
 

--- a/client/src/components/chat/MessageInput.js
+++ b/client/src/components/chat/MessageInput.js
@@ -225,6 +225,12 @@ const MessageInput = ({ chatId, onTyping, onInsertMention }) => {
       }
       return;
     }
+    if (e.key === 'Escape' && replyTo) {
+      e.preventDefault();
+      cancelReply();
+      setTimeout(() => inputRef.current?.focus(), 0);
+      return;
+    }
     if (e.altKey && e.key === 'ArrowUp') {
       e.preventDefault();
       const last = [...messages].reverse().find(m => m.sender._id !== currentUser._id);
@@ -276,18 +282,32 @@ const MessageInput = ({ chatId, onTyping, onInsertMention }) => {
   };
 
   return (
-    <div className="py-3 relative">
+    <div className={`py-3 relative ${replyTo ? 'pt-12' : ''}`}>
       {replyTo && (
-        <div className="mb-2 flex items-center justify-between bg-gray-200 dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-md px-3 py-2">
-          <div className="overflow-hidden">
-            <div className="text-xs text-gray-500">
-              {replyTo.sender?.name || 'Unknown'}
+        <div
+          className="absolute top-0 left-0 right-0 flex h-10 items-center justify-between rounded-md border border-gray-300 dark:border-gray-500 bg-gray-100 dark:bg-gray-700 px-3"
+        >
+          {replyTo.isUnavailable ? (
+            <div className="text-sm text-gray-500">Original message unavailable</div>
+          ) : (
+            <div className="overflow-hidden">
+              <div className="text-xs text-gray-500">
+                {replyTo.sender?.name || 'Unknown'}
+              </div>
+              <div className="text-sm truncate max-w-xs">
+                {replyTo.content || replyTo.text || ''}
+              </div>
             </div>
-            <div className="text-sm truncate max-w-xs">
-              {replyTo.content || replyTo.text || ''}
-            </div>
-          </div>
-          <button onClick={cancelReply} className="ml-2 text-gray-600">
+          )}
+          <button
+            onClick={() => {
+              cancelReply();
+              inputRef.current?.focus();
+            }}
+            aria-label="Cancel reply"
+            tabIndex={2}
+            className="ml-2 text-gray-600"
+          >
             &times;
           </button>
         </div>
@@ -320,11 +340,12 @@ const MessageInput = ({ chatId, onTyping, onInsertMention }) => {
       
       {/* Message input form */}
       <form onSubmit={handleSubmit} className="flex items-end gap-2">
-        <button 
+        <button
           type="button"
           onClick={() => fileInputRef.current.click()}
           className="p-2 text-gray-500 dark:text-gray-400 hover:text-primary-600 focus:outline-none"
           aria-label="Attach file"
+          tabIndex={-1}
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
@@ -347,6 +368,7 @@ const MessageInput = ({ chatId, onTyping, onInsertMention }) => {
           onKeyUp={handleCaretChange}
           onClick={handleCaretChange}
           placeholder="Message"
+          tabIndex={1}
           className="flex-1 px-3 py-2 rounded-md bg-white dark:bg-gray-800 dark:text-gray-100 border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500"
         />
         
@@ -355,6 +377,7 @@ const MessageInput = ({ chatId, onTyping, onInsertMention }) => {
           className="p-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
           disabled={message === '' && attachments.length === 0}
           aria-label="Send message"
+          tabIndex={3}
         >
           <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />

--- a/client/src/components/chat/MessageItem.js
+++ b/client/src/components/chat/MessageItem.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ArrowUturnRightIcon } from '@heroicons/react/24/outline';
 import { format } from 'date-fns';
 import { SocketContext } from '../../contexts/SocketContext';
 import { useChat } from '../../hooks/useChat';
@@ -231,19 +230,11 @@ const MessageItem = React.forwardRef(({ message, isOwn, onDelete, onReply }, ref
       )}
 
       <div className="absolute top-1 right-1 flex items-center gap-2 z-20">
-        {onReply && (
-          <button
-            onClick={onReply}
-            className="p-1 hover:bg-gray-200 rounded"
-            title="Reply"
-          >
-            <ArrowUturnRightIcon className="h-4 w-4" />
-          </button>
-        )}
         <MessageActionsMenu
           isOpen={showMenu}
           onOpen={() => setShowMenu(true)}
           onClose={() => setShowMenu(false)}
+          onReply={onReply}
           onCopy={handleCopy}
           onStartThread={() => openThread(message)}
           onDelete={handleDelete}

--- a/client/src/contexts/ChatContext.js
+++ b/client/src/contexts/ChatContext.js
@@ -59,6 +59,11 @@ export const ChatProvider = ({ children }) => {
     setReplyTo(null);
   };
 
+  // Exit reply mode when switching chats
+  useEffect(() => {
+    setReplyTo(null);
+  }, [selectedChat?._id]);
+
   // Fetch all chats when authenticated
   useEffect(() => {
     if (isAuthenticated) {
@@ -202,6 +207,12 @@ export const ChatProvider = ({ children }) => {
           (msg) => msg._id !== messageId
         ),
       }));
+
+      if (replyTo && (replyTo._id === messageId || replyTo.id === messageId)) {
+        setReplyTo((prev) =>
+          prev ? { ...prev, content: '', text: '', isUnavailable: true } : prev
+        );
+      }
 
       // Update chat list with new latest message
       setChats((prevChats) => {
@@ -404,7 +415,7 @@ export const ChatProvider = ({ children }) => {
       socket.off('message:reactionUpdated');
       socket.off('thread:messageCreated');
     };
-  }, [socket, selectedChat, currentUser, activeThreadParent]);
+  }, [socket, selectedChat, currentUser, activeThreadParent, replyTo]);
 
   const fetchChats = async () => {
     setChatLoading(true);


### PR DESCRIPTION
## Summary
- add reply option in message actions menu
- show cancelable reply preview above composer with keyboard escape support
- reset reply mode when switching chats or replying to deleted messages
- remove legacy inline reply button

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b18681de6c833299a346c97fe2a89e