### PR TITLE
feat: support quoted replies

### DIFF
--- a/client/src/components/chat/MessageItem.js
+++ b/client/src/components/chat/MessageItem.js
@@ -42,8 +42,8 @@ const fetchLinkPreview = async (url) => {
   );
 };
 
-const MessageItem = React.forwardRef(({ message, isOwn, onDelete, onReply }, ref) => {
-  const { openThread, currentUser, toggleReaction, replyTo } = useChat();
+const MessageItem = React.forwardRef(({ message, isOwn, onDelete, onReply, scrollToMessage }, ref) => {
+  const { openThread, currentUser, toggleReaction, replyTo, ensureMessageLoaded } = useChat();
   const socket = React.useContext(SocketContext);
   const containerRef = React.useRef(null);
   const setRefs = (el) => {
@@ -264,6 +264,37 @@ const MessageItem = React.forwardRef(({ message, isOwn, onDelete, onReply }, ref
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}
     >
+      {message.replyTo && (
+        <div
+          className="mb-1 p-2 rounded bg-gray-100 dark:bg-gray-700 border-l-2 border-blue-500 cursor-pointer overflow-hidden"
+          onClick={async () => {
+            const ok = await ensureMessageLoaded(message.replyTo.id);
+            if (ok && scrollToMessage) scrollToMessage(message.replyTo.id);
+          }}
+        >
+          {message.replyTo.isUnavailable ? (
+            <div className="text-sm text-gray-500">Original message unavailable</div>
+          ) : (
+            <div>
+              <div className="text-xs text-gray-500">
+                {message.replyTo.senderId === (currentUser?._id || currentUser?.id)
+                  ? 'You'
+                  : message.replyTo.senderName}
+              </div>
+              <div className="text-sm truncate flex items-center gap-2">
+                {message.replyTo.thumbUrl && (
+                  <img
+                    src={message.replyTo.thumbUrl}
+                    alt="thumb"
+                    className="w-8 h-8 object-cover rounded"
+                  />
+                )}
+                {message.replyTo.excerpt}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
       {text && (
         <div className="text-[15px] leading-6 whitespace-pre-wrap break-words">
           {linkify(text)}

--- a/client/src/components/chat/MessageItem.test.js
+++ b/client/src/components/chat/MessageItem.test.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MessageItem from './MessageItem';
+import { ChatContext } from '../../contexts/ChatContext';
+
+jest.mock('axios', () => ({
+  create: () => ({
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  }),
+}));
+jest.mock('@floating-ui/react-dom', () => ({
+  useFloating: () => ({ x: 0, y: 0, reference: jest.fn(), floating: jest.fn(), strategy: 'absolute', middlewareData: {} }),
+  offset: () => {},
+  flip: () => {},
+  shift: () => {},
+  arrow: () => {},
+}));
+jest.mock('./MessageActionsMenu', () => () => <div />);
+
+describe('MessageItem reply block', () => {
+  const renderWithContext = (ui, contextValue) => {
+    return render(
+      <ChatContext.Provider value={contextValue}>{ui}</ChatContext.Provider>
+    );
+  };
+
+  it('renders quoted reply and navigates on click', async () => {
+    const ensureMessageLoaded = jest.fn().mockResolvedValue(true);
+    const scrollToMessage = jest.fn();
+    const message = {
+      _id: 'm2',
+      content: 'Hi',
+      createdAt: new Date().toISOString(),
+      sender: { _id: 'u1' },
+      status: 'sent',
+      replyTo: {
+        id: 'm1',
+        senderId: 'u2',
+        senderName: 'Alice',
+        excerpt: 'Hello there',
+        createdAt: new Date().toISOString(),
+      },
+    };
+    const contextValue = {
+      openThread: jest.fn(),
+      currentUser: { _id: 'u1' },
+      toggleReaction: jest.fn(),
+      replyTo: null,
+      ensureMessageLoaded,
+    };
+    renderWithContext(
+      <MessageItem
+        message={message}
+        isOwn={false}
+        onDelete={jest.fn()}
+        onReply={jest.fn()}
+        scrollToMessage={scrollToMessage}
+      />,
+      contextValue
+    );
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Hello there')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Hello there'));
+    await waitFor(() => expect(ensureMessageLoaded).toHaveBeenCalledWith('m1'));
+    await waitFor(() => expect(scrollToMessage).toHaveBeenCalledWith('m1'));
+  });
+
+  it('shows fallback when original message unavailable', () => {
+    const message = {
+      _id: 'm2',
+      content: 'Hi',
+      createdAt: new Date().toISOString(),
+      sender: { _id: 'u1' },
+      status: 'sent',
+      replyTo: { id: 'm1', isUnavailable: true },
+    };
+    const contextValue = {
+      openThread: jest.fn(),
+      currentUser: { _id: 'u1' },
+      toggleReaction: jest.fn(),
+      replyTo: null,
+      ensureMessageLoaded: jest.fn().mockResolvedValue(false),
+    };
+    renderWithContext(
+      <MessageItem
+        message={message}
+        isOwn={false}
+        onDelete={jest.fn()}
+        onReply={jest.fn()}
+        scrollToMessage={jest.fn()}
+      />,
+      contextValue
+    );
+    expect(
+      screen.getByText('Original message unavailable')
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/contexts/ChatContext.hydration.test.js
+++ b/client/src/contexts/ChatContext.hydration.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { ChatProvider, ChatContext } from './ChatContext';
+import { AuthContext } from './AuthContext';
+import { SocketContext } from './SocketContext';
+import * as messageService from '../services/messageService';
+
+jest.mock('../services/messageService');
+jest.mock('axios', () => ({
+  create: () => ({
+    interceptors: {
+      request: { use: jest.fn(), eject: jest.fn() },
+      response: { use: jest.fn(), eject: jest.fn() },
+    },
+  }),
+}));
+jest.mock('@floating-ui/react-dom', () => ({
+  useFloating: () => ({ x: 0, y: 0, reference: jest.fn(), floating: jest.fn(), strategy: 'absolute', middlewareData: {} }),
+  offset: () => {},
+  flip: () => {},
+  shift: () => {},
+  arrow: () => {},
+}));
+
+describe('ChatContext reply hydration', () => {
+  it('hydrates reply data when missing', async () => {
+    const msg = {
+      _id: 'm2',
+      chat: { _id: 'c1' },
+      sender: { _id: 'u1', name: 'Bob' },
+      createdAt: new Date().toISOString(),
+      replyTo: { id: 'm1' },
+    };
+    messageService.getMessages.mockResolvedValue({ items: [msg], hasMore: false, nextCursor: null });
+    messageService.getMessageById.mockResolvedValue({
+      _id: 'm1',
+      sender: { _id: 'u2', name: 'Alice' },
+      content: 'hello',
+      createdAt: new Date().toISOString(),
+      attachments: [],
+    });
+    const wrapper = ({ children }) => (
+      <AuthContext.Provider value={{ currentUser: { _id: 'u1' }, isAuthenticated: true }}>
+        <SocketContext.Provider value={{ socket: null }}>
+          <ChatProvider>{children}</ChatProvider>
+        </SocketContext.Provider>
+      </AuthContext.Provider>
+    );
+    const { result } = renderHook(() => React.useContext(ChatContext), { wrapper });
+    await act(async () => {
+      await result.current.fetchMessages('c1');
+    });
+    const hydrated = result.current.messages[0].replyTo;
+    expect(hydrated.senderName).toBe('Alice');
+    expect(hydrated.excerpt).toBe('hello');
+    expect(messageService.getMessageById).toHaveBeenCalledWith('m1');
+  });
+});

--- a/client/src/services/messageService.js
+++ b/client/src/services/messageService.js
@@ -133,3 +133,12 @@ export const uploadAttachments = async (files) => {
     throw error.response?.data || { message: 'Failed to upload files' };
   }
 };
+
+export const getMessageById = async (id) => {
+  try {
+    const response = await api.get(`/messages/${id}`);
+    return response.data;
+  } catch (error) {
+    throw error.response?.data || { message: 'Failed to fetch message' };
+  }
+};

--- a/server/models/message.model.js
+++ b/server/models/message.model.js
@@ -26,9 +26,15 @@ const messageSchema = new mongoose.Schema(
       ref: 'Message',
       default: null
     },
+    // Stores a minimal snapshot of the replied-to message so clients can
+    // render a quoted block without having to fetch the original message.
     replyToSnapshot: {
+      senderId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
       senderName: { type: String },
-      text: { type: String }
+      type: { type: String }, // "text", "image", "file", "audio"
+      excerpt: { type: String },
+      thumbUrl: { type: String },
+      createdAt: { type: Date }
     },
     threadCount: {
       type: Number,

--- a/server/routes/message.routes.js
+++ b/server/routes/message.routes.js
@@ -11,6 +11,7 @@ const {
   uploadAttachments,
   getThread,
   toggleReaction,
+  getMessageById,
 } = require('../controllers/message.controller');
 const multer = require('multer');
 const { isValidFileType } = require('../utils/fileUpload');
@@ -48,6 +49,9 @@ router.post('/:id/ack-read', ackRead);
 
 // Get a message thread
 router.get('/:id/thread', getThread);
+
+// Get a single message
+router.get('/:id', getMessageById);
 
 // Toggle reaction
 router.post('/:id/reactions', toggleReaction);


### PR DESCRIPTION
## Summary
- extend message schema and APIs to expose detailed `replyTo` info
- hydrate and navigate to replied messages on the client
- render quoted reply blocks and add tests for hydration and fallback

## Testing
- `CI=true npm test src/components/chat/MessageItem.test.js src/contexts/ChatContext.hydration.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1932d3e54833282730c55565772f6