### PR TITLE
fix: remove mobile bubble right gutter

### DIFF
--- a/client/src/components/chat/MessageItem.js
+++ b/client/src/components/chat/MessageItem.js
@@ -297,7 +297,9 @@ const MessageItem = React.forwardRef(({ message, isOwn, onDelete, onReply, scrol
   return (
     <div
       ref={setRefs}
-      className="relative group pr-12 select-none"
+      className={`relative group select-none md:pr-12 ${
+        isOwn ? 'self-end ml-auto max-w-[95%]' : ''
+      }`}
       style={{ WebkitTouchCallout: 'none' }}
       tabIndex={0}
       onKeyDown={handleKeyDown}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -95,6 +95,8 @@
   @apply w-full mx-auto;
   max-width: 1000px;
   padding: 16px;
+  padding-right: calc(16px + env(safe-area-inset-right, 0));
+  padding-left: calc(16px + env(safe-area-inset-left, 0));
 }
 
 /* Message styles */


### PR DESCRIPTION
## Summary
- drop action shelf padding on small screens and align own bubbles to the right
- include safe-area inset in chat column padding to prevent extra right gutter

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b1a606d71c8332a530298b48826c18