### PR TITLE
feat: add responsive drawer header with overflow menu

### DIFF
--- a/client/src/components/chat/Sidebar.js
+++ b/client/src/components/chat/Sidebar.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useAuth } from '../../hooks/useAuth';
 import { useChat } from '../../hooks/useChat';
 import { useDebounce } from '../../hooks/useDebounce';
@@ -9,6 +9,7 @@ import { useTheme } from '../../hooks/useTheme';
 import ChatList from './ChatList';
 import UserSearchList from './UserSearchList';
 import LoadingSpinner from '../common/LoadingSpinner';
+import OverflowMenu from '../common/OverflowMenu';
 
 const Sidebar = ({ 
   isMobileMenuOpen, 
@@ -20,6 +21,8 @@ const Sidebar = ({
   const { currentUser, logout } = useAuth();
   const { chats, chatLoading, fetchChats, createOrAccessChat, getTotalUnreadCount } = useChat();
   const { theme, toggleTheme } = useTheme();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const overflowBtnRef = useRef(null);
   
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState([]);
@@ -84,66 +87,73 @@ const Sidebar = ({
       className={`fixed md:static inset-y-0 left-0 z-30 transform ${isMobileMenuOpen ? 'translate-x-0' : '-translate-x-full'} md:translate-x-0 transition-transform duration-300 w-64 md:w-80 bg-gradient-to-b from-gray-100 to-gray-200 dark:from-gray-800 dark:to-gray-700 border-r border-gray-200 dark:border-gray-600 flex flex-col h-full shadow-lg`}
     >
       {/* Header */}
-      <div className="p-4 border-b border-gray-200 dark:border-gray-600 flex items-center justify-between">
-        <div className="flex items-center">
-          <img
-            src={currentUser?.avatar || `https://ui-avatars.com/api/?name=${encodeURIComponent(currentUser?.name || 'User')}&background=random`}
-            alt={currentUser?.name}
-            className="h-10 w-10 rounded-full object-cover"
-          />
-          <div className="ml-3">
-            <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100">{currentUser?.name || 'User'}</h2>
-            <p className="text-sm text-gray-500 dark:text-gray-400">{currentUser?.status || 'Online'}</p>
-          </div>
+      <div
+        className="border-b border-gray-200 dark:border-gray-600 grid grid-cols-[48px_1fr_auto] items-center gap-3 px-4 pb-4"
+        style={{ paddingTop: 'calc(env(safe-area-inset-top, 0px) + 1rem)' }}
+      >
+        <img
+          src={currentUser?.avatar || `https://ui-avatars.com/api/?name=${encodeURIComponent(currentUser?.name || 'User')}&background=random`}
+          alt={currentUser?.name}
+          className="h-12 w-12 rounded-full object-cover shrink-0"
+        />
+        <div className="min-w-0">
+          <h2 className="font-bold text-base text-gray-800 dark:text-gray-100 truncate">
+            {currentUser?.name || 'User'}
+          </h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400">{currentUser?.status || 'Online'}</p>
         </div>
-        <div className="flex">
-          <button
-            onClick={openProfileModal}
-            className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600"
-            aria-label="Profile"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-            </svg>
-          </button>
-          <button
-            onClick={handleLogout}
-            className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 ml-1"
-            aria-label="Logout"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-            </svg>
-          </button>
-          <button
-            onClick={toggleTheme}
-            className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 ml-1"
-            aria-label="Toggle theme"
-          >
-            {theme === 'dark' ? (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5 text-yellow-400"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4.22 2.22a1 1 0 011.42 0l.7.7a1 1 0 11-1.42 1.42l-.7-.7a1 1 0 010-1.42zM17 9a1 1 0 100 2h1a1 1 0 100-2h-1zM4.22 4.22a1 1 0 00-1.42 1.42l.7.7a1 1 0 001.42-1.42l-.7-.7zM3 9a1 1 0 100 2H2a1 1 0 100-2h1zm1.22 6.78a1 1 0 011.42 0l.7.7a1 1 0 01-1.42 1.42l-.7-.7a1 1 0 010-1.42zM10 17a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zm6.78-1.22a1 1 0 00-1.42-1.42l-.7.7a1 1 0 001.42 1.42l.7-.7zM10 5a5 5 0 100 10 5 5 0 000-10z" />
+        <div className="flex items-center gap-1 shrink-0">
+          <div className="flex items-center gap-1 max-[480px]:hidden">
+            <button
+              onClick={openProfileModal}
+              className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600"
+              aria-label="Profile"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
               </svg>
-                ) : (
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-5 w-5 text-gray-800"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
-                    <path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />
-                  </svg>
-                )}
-          </button>
+            </button>
+            <button
+              onClick={handleLogout}
+              className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600"
+              aria-label="Logout"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+              </svg>
+            </button>
+            <button
+              onClick={toggleTheme}
+              className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600"
+              aria-label="Toggle theme"
+            >
+              {theme === 'dark' ? (
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4.22 2.22a1 1 0 011.42 0l.7.7a1 1 0 11-1.42 1.42l-.7-.7a1 1 0 010-1.42zM17 9a1 1 0 100 2h1a1 1 0 100-2h-1zM4.22 4.22a1 1 0 00-1.42 1.42l.7.7a1 1 0 001.42-1.42l-.7-.7zM3 9a1 1 0 100 2H2a1 1 0 100-2h1zm1.22 6.78a1 1 0 011.42 0l.7.7a1 1 0 01-1.42 1.42l-.7-.7a1 1 0 010-1.42zM10 17a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zm6.78-1.22a1 1 0 00-1.42-1.42l-.7.7a1 1 0 001.42 1.42l.7-.7zM10 5a5 5 0 100 10 5 5 0 000-10z" />
+                </svg>
+              ) : (
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-800" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />
+                </svg>
+              )}
+            </button>
+          </div>
+          <div className="min-[481px]:hidden">
+            <button
+              ref={overflowBtnRef}
+              onClick={() => setMenuOpen(true)}
+              className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600"
+              aria-label="Menu"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600 dark:text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6h.01M12 12h.01M12 18h.01" />
+              </svg>
+            </button>
+          </div>
           <button
             onClick={toggleMobileMenu}
-            className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 ml-1 md:hidden"
+            className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600 hidden max-[480px]:block"
             aria-label="Close menu"
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -152,6 +162,36 @@ const Sidebar = ({
           </button>
         </div>
       </div>
+      <OverflowMenu
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        anchorEl={overflowBtnRef.current}
+      >
+        <button
+          onClick={() => { setMenuOpen(false); openProfileModal(); }}
+          className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600"
+        >
+          Profile
+        </button>
+        <button
+          onClick={() => { setMenuOpen(false); }}
+          className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600"
+        >
+          Settings
+        </button>
+        <button
+          onClick={() => { setMenuOpen(false); toggleTheme(); }}
+          className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600"
+        >
+          Theme
+        </button>
+        <button
+          onClick={() => { setMenuOpen(false); handleLogout(); }}
+          className="w-full text-left px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600"
+        >
+          Logout
+        </button>
+      </OverflowMenu>
       
       {/* Search */}
       <div className="p-4 border-b border-gray-200 dark:border-gray-600">

--- a/client/src/components/common/OverflowMenu.js
+++ b/client/src/components/common/OverflowMenu.js
@@ -1,0 +1,81 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+const focusableSelectors = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+const OverflowMenu = ({ open, onClose, anchorEl, children }) => {
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const previousActive = document.activeElement;
+    const firstFocusable = menuRef.current?.querySelector(focusableSelectors);
+    firstFocusable?.focus();
+
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key === 'Tab') {
+        const focusable = menuRef.current?.querySelectorAll(focusableSelectors);
+        if (!focusable || focusable.length === 0) return;
+        const index = Array.prototype.indexOf.call(focusable, document.activeElement);
+        if (e.shiftKey) {
+          if (index === 0) {
+            e.preventDefault();
+            focusable[focusable.length - 1].focus();
+          }
+        } else {
+          if (index === focusable.length - 1) {
+            e.preventDefault();
+            focusable[0].focus();
+          }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previousActive && previousActive.focus();
+    };
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  let style = { top: '1rem', right: '1rem' };
+  if (anchorEl) {
+    const rect = anchorEl.getBoundingClientRect();
+    style = { top: `${rect.bottom + 8}px`, right: `${window.innerWidth - rect.right}px` };
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50" onMouseDown={onClose}>
+      <div
+        ref={menuRef}
+        className="absolute bg-white dark:bg-gray-700 rounded-md shadow-lg py-2 w-48"
+        style={style}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default OverflowMenu;
+

--- a/client/src/pages/Chat.js
+++ b/client/src/pages/Chat.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useAuth } from '../hooks/useAuth';
 import { useChat } from '../hooks/useChat';
 
@@ -20,13 +20,6 @@ const Chat = () => {
   const [isUserProfileModalOpen, setIsUserProfileModalOpen] = useState(false);
   const [isGroupInfoModalOpen, setIsGroupInfoModalOpen] = useState(false);
   const [selectedUser, setSelectedUser] = useState(null);
-
-  // Close mobile menu when a chat is selected
-  useEffect(() => {
-    if (selectedChat && isMobileMenuOpen) {
-      setIsMobileMenuOpen(false);
-    }
-  }, [selectedChat]);
 
   const toggleMobileMenu = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen);


### PR DESCRIPTION
## Summary
- refactor sidebar header into a 3-column grid and add mobile overflow menu
- add reusable `OverflowMenu` portal with focus trap
- keep sidebar open until explicitly closed and allow closing by tapping outside

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b5519b9a5c833296db29dfaa43baaa