### PR TITLE
Fix mobile overlay to dismiss sidebar on chat select

### DIFF
--- a/client/src/components/chat/ChatList.js
+++ b/client/src/components/chat/ChatList.js
@@ -5,7 +5,7 @@ import { useSocket } from '../../hooks/useSocket';
 import { formatDistanceToNow } from 'date-fns';
 import MessageStatusTicks from './MessageStatusTicks';
 
-const ChatList = ({ chats, openUserProfileModal }) => {
+const ChatList = ({ chats, openUserProfileModal, onChatSelect }) => {
   const { currentUser } = useAuth();
   const { selectedChat, setSelectedChat, unreadCounts } = useChat();
   const { isUserOnline } = useSocket();
@@ -81,7 +81,10 @@ const ChatList = ({ chats, openUserProfileModal }) => {
           <div
             key={chat._id}
             className={`p-4 cursor-pointer rounded-lg transition-colors duration-200 bg-gray-100 dark:bg-gray-700 hover:shadow-md hover:bg-gray-200 dark:hover:bg-gray-600 ${isSelected ? 'bg-gray-200 dark:bg-gray-600 shadow' : ''}`}
-            onClick={() => setSelectedChat(chat)}
+            onClick={() => {
+              setSelectedChat(chat);
+              if (onChatSelect) onChatSelect();
+            }}
           >
             <div className="flex items-center">
               <div className="relative">

--- a/client/src/components/chat/Sidebar.js
+++ b/client/src/components/chat/Sidebar.js
@@ -266,7 +266,13 @@ const Sidebar = ({
               <p className="text-sm">Search for users to start chatting</p>
             </div>
           ) : (
-            <ChatList chats={chats} openUserProfileModal={openUserProfileModal} />
+            <ChatList
+              chats={chats}
+              openUserProfileModal={openUserProfileModal}
+              onChatSelect={() => {
+                if (isMobileMenuOpen) toggleMobileMenu();
+              }}
+            />
           )
         ) : (
           // Search Results

--- a/client/src/pages/Chat.js
+++ b/client/src/pages/Chat.js
@@ -62,7 +62,10 @@ const Chat = () => {
   return (
     <div className="h-full flex relative overscroll-none min-h-0">
       {isMobileMenuOpen && (
-        <div className="fixed inset-0 bg-black/40 z-20 md:hidden transition-opacity"></div>
+        <div
+          className="fixed inset-0 bg-black/40 z-20 md:hidden transition-opacity"
+          onClick={toggleMobileMenu}
+        ></div>
       )}
 
       {/* Sidebar */}


### PR DESCRIPTION
## Summary
- Close mobile sidebar after selecting a chat so messages are visible
- Make overlay clickable to dismiss sidebar

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b55c9349648332ae4b3218efc1746d