### PR TITLE
fix: use functional updates for new messages

### DIFF
--- a/client/src/contexts/ChatContext.js
+++ b/client/src/contexts/ChatContext.js
@@ -790,7 +790,7 @@ export const ChatProvider = ({ children }) => {
       }
 
       // Add message to current chat
-      setMessages([...messages, data]);
+      setMessages((prev) => [...prev, data]);
       setMessageCache((prev) => ({
         ...prev,
         [chatId]: [...(prev[chatId] || []), data],


### PR DESCRIPTION
## Summary
- ensure ChatContext state updates use functional form in sendNewMessage to avoid stale closures
- keep message cache merges to existing state

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b566000d188332abc89977a6af4d8a