### PR TITLE
Align message fetch endpoint documentation

### DIFF
--- a/client/src/services/messageService.js
+++ b/client/src/services/messageService.js
@@ -1,7 +1,7 @@
 import api from 'services/apiClient';
 
 /**
- * Get all messages for a chat
+ * Get all messages for a chat via `GET /api/messages?chatId={chatId}`
  * @param {string} chatId - Chat ID
  * @returns {Promise<Array>} List of messages
  */

--- a/server/controllers/message.controller.js
+++ b/server/controllers/message.controller.js
@@ -104,7 +104,7 @@ const sendMessage = async (req, res) => {
 
 /**
  * @desc    Get all messages for a chat
- * @route   GET /api/messages/:chatId
+ * @route   GET /api/messages?chatId={chatId}
  * @access  Private
  */
 const getMessages = async (req, res) => {


### PR DESCRIPTION
## Summary
- Clarify in server controller that messages are fetched via `/api/messages?chatId={chatId}`
- Document the same endpoint pattern in client message service

## Testing
- `cd client && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68b5660429d0833291311f544232668d