### PR TITLE
Ensure typing events include full user objects

### DIFF
--- a/server/services/socket.service.js
+++ b/server/services/socket.service.js
@@ -20,7 +20,13 @@ const socketService = (io) => {
         // Add user to connected users map
         connectedUsers.set(userData._id, socket.id);
         socket.userId = userData._id;
-        
+        // Preserve basic user info for event payloads
+        socket.user = {
+          _id: userData._id,
+          name: userData.name,
+          avatar: userData.avatar,
+        };
+
         // Update user status in database
         await User.findByIdAndUpdate(userData._id, {
           status: 'online',
@@ -30,7 +36,7 @@ const socketService = (io) => {
 
         // Emit online status to all users
         socket.broadcast.emit('user-online', { userId: userData._id });
-        
+
         // Join a room with the user's ID
         socket.join(userData._id);
         socket.emit('connected');
@@ -81,12 +87,12 @@ const socketService = (io) => {
 
     // Handle typing status
     socket.on('typing', (chatId) => {
-      socket.to(chatId).emit('typing', { chatId, userId: socket.userId });
+      socket.to(chatId).emit('typing', { chatId, user: socket.user });
     });
 
     // Handle stop typing status
     socket.on('stop-typing', (chatId) => {
-      socket.to(chatId).emit('stop-typing', { chatId, userId: socket.userId });
+      socket.to(chatId).emit('stop-typing', { chatId, user: socket.user });
     });
 
     // Handle read messages


### PR DESCRIPTION
## Summary
- store basic user info during socket setup so event payloads include complete user objects
- standardize `typing` and `stop-typing` events to emit `{ chatId, user }`

## Testing
- `npm test` (server) *(fails: no test specified)*
- Manual socket test: verified `typing` and `stop-typing` payloads contain full user object


------
https://chatgpt.com/codex/tasks/task_e_68b569facec88332ba24c49d53c4c0eb