### PR TITLE
Handle incremental online user updates

### DIFF
--- a/client/src/contexts/SocketContext.js
+++ b/client/src/contexts/SocketContext.js
@@ -26,12 +26,23 @@ export const SocketProvider = ({ children }) => {
       // Set up event listeners
       newSocket.on('connect', () => {
         console.log('Socket connected');
-        // Emit user connected event with user info
-        newSocket.emit('user:connected', { userId: currentUser._id });
+        // Register the current user with the server
+        newSocket.emit('setup', currentUser);
+        // Request the current list of online users
+        newSocket.emit('get-online-users', (users) => {
+          setOnlineUsers(users);
+        });
       });
 
-      newSocket.on('users:online', (users) => {
-        setOnlineUsers(users);
+      newSocket.on('user-online', ({ userId }) => {
+        setOnlineUsers((prev) => {
+          if (prev.some((u) => u.userId === userId)) return prev;
+          return [...prev, { userId }];
+        });
+      });
+
+      newSocket.on('user-offline', ({ userId }) => {
+        setOnlineUsers((prev) => prev.filter((u) => u.userId !== userId));
       });
 
       newSocket.on('disconnect', () => {

--- a/server/services/socket.service.js
+++ b/server/services/socket.service.js
@@ -39,6 +39,12 @@ const socketService = (io) => {
       }
     });
 
+    // Provide the list of currently connected users
+    socket.on('get-online-users', (callback) => {
+      const users = Array.from(connectedUsers.keys()).map((userId) => ({ userId }));
+      callback(users);
+    });
+
     // Join a chat room
     socket.on('join-chat', (chatId) => {
       socket.join(chatId);


### PR DESCRIPTION
## Summary
- replace bulk `users:online` socket event with incremental `user-online`/`user-offline` handlers and initial fetch
- add server handler to return list of currently connected users

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm test -- --watchAll=false` (client)

------
https://chatgpt.com/codex/tasks/task_e_68b569ff64e483329d752739b6dd962e