### PR TITLE
Use setup event and handle user status updates

### DIFF
--- a/client/src/contexts/SocketContext.js
+++ b/client/src/contexts/SocketContext.js
@@ -26,12 +26,48 @@ export const SocketProvider = ({ children }) => {
       // Set up event listeners
       newSocket.on('connect', () => {
         console.log('Socket connected');
-        // Emit user connected event with user info
-        newSocket.emit('user:connected', { userId: currentUser._id });
+        // Complete socket setup with current user info
+        newSocket.emit('setup', currentUser);
       });
 
-      newSocket.on('users:online', (users) => {
+      // Receive initial list of online users
+      newSocket.on('online-users', (users) => {
         setOnlineUsers(users);
+      });
+
+      // User came online
+      newSocket.on('user-online', ({ userId }) => {
+        setOnlineUsers((prev) => {
+          if (prev.some((u) => u.userId === userId)) return prev;
+          return [...prev, { userId, status: 'online' }];
+          
+        });
+      });
+
+      // User went offline
+      newSocket.on('user-offline', ({ userId }) => {
+        setOnlineUsers((prev) => prev.filter((u) => u.userId !== userId));
+      });
+
+      // User changed status
+      newSocket.on('user-status-change', ({ userId, status }) => {
+        setOnlineUsers((prev) => {
+          const index = prev.findIndex((u) => u.userId === userId);
+          if (status === 'offline') {
+            if (index !== -1) {
+              const updated = [...prev];
+              updated.splice(index, 1);
+              return updated;
+            }
+            return prev;
+          }
+          if (index !== -1) {
+            const updated = [...prev];
+            updated[index] = { userId, status };
+            return updated;
+          }
+          return [...prev, { userId, status }];
+        });
       });
 
       newSocket.on('disconnect', () => {

--- a/server/services/socket.service.js
+++ b/server/services/socket.service.js
@@ -18,8 +18,8 @@ const socketService = (io) => {
     socket.on('setup', async (userData) => {
       try {
         // Add user to connected users map
-        connectedUsers.set(userData._id, socket.id);
-        socket.userId = userData._id;
+        connectedUsers.set(userData._id.toString(), socket.id);
+        socket.userId = userData._id.toString();
         
         // Update user status in database
         await User.findByIdAndUpdate(userData._id, {
@@ -29,10 +29,17 @@ const socketService = (io) => {
         });
 
         // Emit online status to all users
-        socket.broadcast.emit('user-online', { userId: userData._id });
-        
+        socket.broadcast.emit('user-online', { userId: socket.userId });
+
         // Join a room with the user's ID
-        socket.join(userData._id);
+        socket.join(socket.userId);
+
+        // Send list of currently online users to the connected client
+        const onlineUsers = Array.from(connectedUsers.keys()).map((id) => ({
+          userId: id,
+          status: 'online',
+        }));
+        socket.emit('online-users', onlineUsers);
         socket.emit('connected');
       } catch (error) {
         console.error('Socket setup error:', error);
@@ -233,10 +240,10 @@ const socketService = (io) => {
           await user.save();
 
           // Remove from connected users map
-          connectedUsers.delete(user._id.toString());
+          connectedUsers.delete(socket.userId);
 
           // Broadcast offline status
-          socket.broadcast.emit('user-offline', { userId: user._id });
+          socket.broadcast.emit('user-offline', { userId: socket.userId });
         }
       } catch (error) {
         console.error('Disconnect error:', error);


### PR DESCRIPTION
## Summary
- emit `setup` when socket connects and listen for user online/offline/status updates
- send current online user list from server after setup
- store user IDs as strings so disconnected users are removed from online map

## Testing
- `cd server && npm test` (fails: no test specified)
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b569e17850833289cac9d002b095bd