### PR TITLE
fix: prevent chat message overlap

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -170,7 +170,7 @@
 }
 
 .message-row {
-  display: block;
+  /* Allow Tailwind's grid classes to control layout to prevent overlapping */
   min-width: 0;
 }
 


### PR DESCRIPTION
## Summary
- remove overriding block layout from `.message-row` so Tailwind grid can align messages without overlap

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b56f622cdc8332838b5db0d393f509