### PR TITLE
Use time gap threshold for chat time divider

### DIFF
--- a/client/src/components/chat/MessageGroup.js
+++ b/client/src/components/chat/MessageGroup.js
@@ -3,6 +3,8 @@ import MessageItem from './MessageItem';
 import TimeDivider from './TimeDivider';
 import linkify from '../../utils/linkify';
 
+const DIVIDER_THRESHOLD_MS = 5 * 60 * 1000;
+
 const avatarUrl = (sender) => {
   if (!sender) return '';
   return (
@@ -26,11 +28,8 @@ const MessageGroup = ({
     const elements = [];
     group.items.forEach((m) => {
       const msgDate = new Date(m.createdAt);
-      const minuteChanged =
-        !last ||
-        msgDate.getHours() !== last.getHours() ||
-        msgDate.getMinutes() !== last.getMinutes();
-      if (minuteChanged) {
+      const showDivider = !last || msgDate - last >= DIVIDER_THRESHOLD_MS;
+      if (showDivider) {
         elements.push(
           <TimeDivider key={`time-${m.id || m._id}`} time={msgDate} />
         );
@@ -54,11 +53,8 @@ const MessageGroup = ({
   let prevType = 'divider';
   group.items.forEach((m) => {
     const msgDate = new Date(m.createdAt);
-    const minuteChanged =
-      !last ||
-      msgDate.getHours() !== last.getHours() ||
-      msgDate.getMinutes() !== last.getMinutes();
-    if (minuteChanged) {
+    const showDivider = !last || msgDate - last >= DIVIDER_THRESHOLD_MS;
+    if (showDivider) {
       elements.push(
         <TimeDivider key={`time-${m.id || m._id}`} time={msgDate} />
       );


### PR DESCRIPTION
## Summary
- Only insert a TimeDivider when the gap between messages exceeds five minutes to reduce noise in chat windows.

## Testing
- `cd client && CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b57570018c833284ace92dfd25a74b