### PR TITLE
Enhance time divider styling

### DIFF
--- a/client/src/components/chat/TimeDivider.js
+++ b/client/src/components/chat/TimeDivider.js
@@ -3,7 +3,9 @@ import { format } from 'date-fns';
 
 const TimeDivider = ({ time }) => (
   <div className="time-divider">
+    <hr />
     <span>{format(new Date(time), 'h:mm a')}</span>
+    <hr />
   </div>
 );
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -179,11 +179,15 @@
 }
 
 .time-divider {
-  @apply my-2 text-center;
+  @apply my-2 flex items-center text-center;
+}
+
+.time-divider hr {
+  @apply flex-1 border-t border-gray-200 dark:border-gray-700;
 }
 
 .time-divider span {
-  @apply text-xs text-gray-400;
+  @apply mx-3 text-xs text-gray-400 dark:text-gray-500;
 }
 
 


### PR DESCRIPTION
## Summary
- Wrap time divider timestamps with horizontal rules for clearer chat separation
- Add flex layout and dark mode-aware styling for time divider lines

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b577ed59148332b20d631f7704306e