### PR TITLE
Reduce message group margin

### DIFF
--- a/client/src/components/chat/MessageGroup.js
+++ b/client/src/components/chat/MessageGroup.js
@@ -44,7 +44,7 @@ const MessageGroup = ({
       );
       last = msgDate;
     });
-    return <div className="mb-3">{elements}</div>;
+    return <div className="mb-1">{elements}</div>;
   }
 
   const isOwn = (group.sender._id || group.sender.id) === (currentUser._id || currentUser.id);
@@ -106,7 +106,7 @@ const MessageGroup = ({
     last = msgDate;
   });
 
-  return <div className="group mb-3">{elements}</div>;
+  return <div className="group mb-1">{elements}</div>;
 };
 
 export default MessageGroup;


### PR DESCRIPTION
## Summary
- lower message group container spacing from `mb-3` to `mb-1`
- maintain row gaps and TimeDivider spacing

## Testing
- `cd client && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b579e873bc8332827eb3621d8c5ae5