### PR TITLE
Handle equal timestamps in message grouping

### DIFF
--- a/client/src/utils/groupMessages.js
+++ b/client/src/utils/groupMessages.js
@@ -1,4 +1,13 @@
 export function groupMessages(messages, windowMinutes = 5) {
+  const sorted = messages
+    .map((m, index) => ({ m, index }))
+    .sort((a, b) => {
+      const diff =
+        new Date(a.m.createdAt).getTime() -
+        new Date(b.m.createdAt).getTime();
+      return diff !== 0 ? diff : a.index - b.index;
+    })
+    .map(({ m }) => m);
   const groups = [];
   const isSameGroup = (a, b) => {
     const senderA = a.sender?.id || a.sender?._id;
@@ -10,8 +19,8 @@ export function groupMessages(messages, windowMinutes = 5) {
     );
   };
 
-  for (let i = 0; i < messages.length; i++) {
-    const m = messages[i];
+  for (let i = 0; i < sorted.length; i++) {
+    const m = sorted[i];
     if (m.isSystem) {
       groups.push({ key: `sys-${m.id || m._id}`, sender: null, startAt: new Date(m.createdAt), items: [m] });
       continue;

--- a/client/src/utils/groupMessages.test.js
+++ b/client/src/utils/groupMessages.test.js
@@ -42,4 +42,14 @@ describe('groupMessages', () => {
     expect(groups).toHaveLength(3);
     expect(groups[1].sender).toBeNull();
   });
+
+  it('maintains order for messages with identical timestamps', () => {
+    const msgs = [
+      { id: '1', sender: userA, createdAt: '2020-01-01T00:00:00Z' },
+      { id: '2', sender: userB, createdAt: '2020-01-01T00:00:00Z' },
+      { id: '3', sender: userA, createdAt: '2020-01-01T00:00:00Z' },
+    ];
+    const groups = groupMessages(msgs);
+    expect(groups.map((g) => g.items[0].id)).toEqual(['1', '2', '3']);
+  });
 });


### PR DESCRIPTION
## Summary
- Ensure `groupMessages` sorts messages stably by timestamp with index-based tie-breaker
- Add regression test verifying order preservation when messages share the same timestamp

## Testing
- `cd client && CI=true npm test -- src/utils/groupMessages.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b58d7718148332937cae269c0f3933