### PR TITLE
Handle invalid timestamps when grouping messages

### DIFF
--- a/client/src/utils/groupMessages.js
+++ b/client/src/utils/groupMessages.js
@@ -1,19 +1,32 @@
 export function groupMessages(messages, windowMinutes = 5) {
+  const windowMs = windowMinutes * 60 * 1000;
+
+  const sorted = messages
+    .filter((m) => !Number.isNaN(Date.parse(m.createdAt)))
+    .sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
+
   const groups = [];
   const isSameGroup = (a, b) => {
     const senderA = a.sender?.id || a.sender?._id;
     const senderB = b.sender?.id || b.sender?._id;
     return (
-      senderA && senderA === senderB &&
-      Math.abs(new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()) <= windowMinutes * 60 * 1000 &&
-      !a.isSystem && !b.isSystem
+      senderA &&
+      senderA === senderB &&
+      Math.abs(Date.parse(a.createdAt) - Date.parse(b.createdAt)) <= windowMs &&
+      !a.isSystem &&
+      !b.isSystem
     );
   };
 
-  for (let i = 0; i < messages.length; i++) {
-    const m = messages[i];
+  for (let i = 0; i < sorted.length; i++) {
+    const m = sorted[i];
     if (m.isSystem) {
-      groups.push({ key: `sys-${m.id || m._id}`, sender: null, startAt: new Date(m.createdAt), items: [m] });
+      groups.push({
+        key: `sys-${m.id || m._id}`,
+        sender: null,
+        startAt: new Date(m.createdAt),
+        items: [m],
+      });
       continue;
     }
     const prevGroup = groups[groups.length - 1];

--- a/client/src/utils/groupMessages.test.js
+++ b/client/src/utils/groupMessages.test.js
@@ -42,4 +42,24 @@ describe('groupMessages', () => {
     expect(groups).toHaveLength(3);
     expect(groups[1].sender).toBeNull();
   });
+
+  it('filters out messages missing createdAt', () => {
+    const msgs = [
+      { id: '1', sender: userA },
+      { id: '2', sender: userA, createdAt: '2020-01-01T00:00:00Z' },
+    ];
+    const groups = groupMessages(msgs);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items[0].id).toBe('2');
+  });
+
+  it('filters out messages with invalid createdAt', () => {
+    const msgs = [
+      { id: '1', sender: userA, createdAt: 'not-a-date' },
+      { id: '2', sender: userA, createdAt: '2020-01-01T00:00:00Z' },
+    ];
+    const groups = groupMessages(msgs);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items[0].id).toBe('2');
+  });
 });


### PR DESCRIPTION
## Summary
- Validate and sort messages by `createdAt` using `Date.parse`
- Ignore messages with missing or malformed `createdAt`
- Test grouping behavior with invalid timestamps

## Testing
- `cd client && CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b58d76115c8332a713d19401336fff